### PR TITLE
Fix: Separate landing page and studio deployments

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,59 @@
+name: Deploy to Firebase Hosting
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          cache: 'npm'
+
+      - name: Install root dependencies
+        run: npm ci
+
+      - name: Install landing page dependencies
+        run: |
+          cd landing-page
+          npm ci
+
+      - name: Build landing page
+        run: npm run build:landing
+        env:
+          NODE_ENV: production
+
+      - name: Build studio app
+        run: npm run build:studio
+        env:
+          NODE_ENV: production
+          VITE_API_KEY: ${{ secrets.VITE_API_KEY }}
+          VITE_VERTEX_PROJECT_ID: ${{ secrets.VITE_VERTEX_PROJECT_ID }}
+          VITE_VERTEX_LOCATION: ${{ secrets.VITE_VERTEX_LOCATION }}
+
+      - name: Verify build outputs
+        run: |
+          echo "Checking landing page build..."
+          ls -la landing-page/out || echo "Landing page build not found!"
+          echo "Checking studio build..."
+          ls -la dist || echo "Studio build not found!"
+
+      - name: Deploy to Firebase Hosting
+        uses: FirebaseExtended/action-hosting-deploy@v0
+        with:
+          repoToken: ${{ secrets.GITHUB_TOKEN }}
+          firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
+          channelId: live
+          projectId: architexture-ai-api
+        env:
+          FIREBASE_CLI_EXPERIMENTS: webframeworks

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,0 +1,175 @@
+# Deployment Guide
+
+## Overview
+
+This project has **two separate deployments**:
+
+1. **Landing Page** - Next.js static site with WebGL effects
+   - URL: https://indiios-v-1-1.web.app
+   - Source: `landing-page/`
+   - Build output: `landing-page/out/`
+
+2. **Studio App** - React + Vite main application
+   - URL: https://indiios-studio.web.app
+   - Source: `src/`
+   - Build output: `dist/`
+
+## Local Development
+
+### Landing Page
+```bash
+cd landing-page
+npm install
+npm run dev
+```
+
+### Studio App
+```bash
+npm install
+npm run dev
+```
+
+## Building for Production
+
+### Build Both Sites
+```bash
+npm run build:all
+```
+
+### Build Landing Page Only
+```bash
+npm run build:landing
+```
+
+### Build Studio App Only
+```bash
+npm run build:studio
+```
+
+## Manual Deployment to Firebase
+
+### Prerequisites
+1. Install Firebase CLI: `npm install -g firebase-tools`
+2. Login: `firebase login`
+3. Select project: `firebase use architexture-ai-api`
+
+### Deploy Both Sites
+```bash
+# Build both sites
+npm run build:all
+
+# Deploy landing page
+firebase deploy --only hosting:landing
+
+# Deploy studio app
+firebase deploy --only hosting:app
+
+# Or deploy both at once
+firebase deploy --only hosting
+```
+
+## Automated Deployment (CI/CD)
+
+The project uses GitHub Actions for automated deployments on merge to `main`.
+
+### Workflow: `.github/workflows/deploy.yml`
+- Triggers on push to `main` or manual workflow dispatch
+- Builds both landing page and studio app
+- Deploys to Firebase Hosting using service account
+
+### Required GitHub Secrets
+- `FIREBASE_SERVICE_ACCOUNT` - Service account JSON for Firebase deployment
+- `VITE_API_KEY` - API key for the studio app (optional)
+- `VITE_VERTEX_PROJECT_ID` - GCP project ID (optional)
+- `VITE_VERTEX_LOCATION` - GCP location (optional)
+
+## Troubleshooting
+
+### Landing page and studio showing the same content
+This happens when `landing-page/out` doesn't exist. Build the landing page first:
+```bash
+npm run build:landing
+```
+
+### Build fails
+1. Clear node_modules and reinstall:
+   ```bash
+   rm -rf node_modules landing-page/node_modules
+   npm install
+   cd landing-page && npm install
+   ```
+
+2. Check Node.js version (requires 20.x):
+   ```bash
+   node --version
+   ```
+
+### Deployment fails
+1. Verify Firebase targets are configured:
+   ```bash
+   firebase target:list
+   ```
+
+2. Set targets if missing:
+   ```bash
+   firebase target:apply hosting landing indiios-v-1-1
+   firebase target:apply hosting app indiios-studio
+   ```
+
+## Architecture
+
+```
+Rndr-AI-v1/
+├── landing-page/          # Next.js landing site
+│   ├── app/              # Next.js app directory
+│   ├── package.json      # Landing page dependencies
+│   └── out/              # Build output (gitignored)
+├── src/                  # Studio app source
+├── dist/                 # Studio build output (gitignored)
+├── firebase.json         # Firebase hosting config
+└── .firebaserc          # Firebase project config
+```
+
+## Firebase Hosting Configuration
+
+### `.firebaserc`
+```json
+{
+  "targets": {
+    "indiios-v-1-1": {
+      "hosting": {
+        "landing": ["indiios-v-1-1"],
+        "app": ["indiios-studio"]
+      }
+    }
+  }
+}
+```
+
+### `firebase.json`
+```json
+{
+  "hosting": [
+    {
+      "target": "landing",
+      "public": "landing-page/out"
+    },
+    {
+      "target": "app",
+      "public": "dist"
+    }
+  ]
+}
+```
+
+## Verification
+
+After deployment, verify both sites are working:
+
+1. **Landing Page**: https://indiios-v-1-1.web.app
+   - Should show WebGL effects and animation
+   - Should have "Enter Studio" or similar CTA
+
+2. **Studio App**: https://indiios-studio.web.app
+   - Should show the main indiiOS studio interface
+   - Should load authentication and workspace features

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
+    "build:landing": "cd landing-page && npm install && npm run build",
+    "build:studio": "vite build",
+    "build:all": "npm run build:landing && npm run build:studio",
     "preview": "vite preview",
     "electron:dev": "tsc -p tsconfig.electron.json && mv dist-electron/preload.js dist-electron/preload.mjs && electron .",
     "electron:build": "tsc -p tsconfig.electron.json && mv dist-electron/preload.js dist-electron/preload.mjs && vite build && electron-builder",


### PR DESCRIPTION
## 🐛 Issue Fixed

The landing page (https://indiios-v-1-1.web.app) was showing the same content as the studio app (https://indiios-studio.web.app) instead of displaying its WebGL landing page with animations.

## 🔍 Root Cause

The landing page was never being built before deployment. The `landing-page/out` directory (configured in `firebase.json`) didn't exist, causing Firebase to potentially fall back to serving the studio app for both URLs.

## ✅ Changes Made

### 1. Added Build Scripts (`package.json`)
- `build:landing` - Builds the Next.js landing page to `landing-page/out`
- `build:studio` - Builds the React/Vite studio app to `dist`
- `build:all` - Builds both landing page and studio in sequence

### 2. Created Firebase Deployment Workflow (`.github/workflows/deploy.yml`)
- Triggers on push to `main` or manual dispatch
- Installs dependencies for both projects
- Builds both landing page and studio app
- Verifies build outputs exist
- Deploys to Firebase Hosting with proper targets

### 3. Added Comprehensive Documentation (`docs/DEPLOYMENT.md`)
- Local development setup instructions
- Build commands for both sites
- Manual and automated deployment procedures
- Troubleshooting guide
- Architecture overview
- Firebase configuration reference

## 🧪 Testing

✅ Built landing page locally - output verified in `landing-page/out/`
✅ Built studio app locally - output verified in `dist/`
✅ Both builds complete without errors
✅ No secrets or sensitive data in commits

## 📦 Deployment

After merge, the GitHub Actions workflow will:
1. Build both landing page and studio app
2. Deploy to Firebase Hosting with correct targets:
   - **Landing** → https://indiios-v-1-1.web.app
   - **Studio** → https://indiios-studio.web.app

## 📝 Required Setup

Before the automated deployment works, add this GitHub secret:
- `FIREBASE_SERVICE_ACCOUNT` - Service account JSON for Firebase deployment

Optional secrets for studio app:
- `VITE_API_KEY`
- `VITE_VERTEX_PROJECT_ID`
- `VITE_VERTEX_LOCATION`

## 🚀 Manual Deployment (if needed)

```bash
# Build both sites
npm run build:all

# Deploy to Firebase
firebase deploy --only hosting:landing  # Landing page
firebase deploy --only hosting:app      # Studio app
firebase deploy --only hosting          # Both
```

## 📊 Impact

- **Landing page** will now show its intended WebGL content
- **Studio app** remains unchanged
- Automated deployments on merge to main
- Clear separation between landing and app deployments

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automated deployment workflow to Firebase Hosting triggered on main branch pushes and manual dispatch

* **Documentation**
  * Added comprehensive deployment guide covering landing page and studio app build and deployment procedures

* **Chores**
  * Added build scripts for landing page, studio app, and combined builds

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->