### PR TITLE
Stabilize sidebar auth mocks and make CommandBar drag test async

### DIFF
--- a/src/core/components/CommandBar.test.tsx
+++ b/src/core/components/CommandBar.test.tsx
@@ -145,7 +145,7 @@ describe('CommandBar', () => {
             expect(agentService.sendMessage).toHaveBeenCalledWith('Hello agent', undefined, undefined);
         });
     });
-    it('handles drag and drop events', () => {
+    it('handles drag and drop events', async () => {
         render(<CommandBar />);
         const dropZone = screen.getByPlaceholderText('Describe your task, drop files, or take a picture...').closest('div');
 
@@ -154,14 +154,16 @@ describe('CommandBar', () => {
 
         // Drag over
         fireEvent.dragOver(dropZone!);
-        expect(screen.getByText('Drop files to attach')).toBeInTheDocument();
+        expect(await screen.findByText('Drop files to attach')).toBeInTheDocument();
         expect(dropZone).toHaveClass('ring-4');
 
         // Drag leave
         fireEvent.dragLeave(dropZone!);
         // expect(screen.getByPlaceholderText('Describe your task, drop files, or take a picture...')).toBeInTheDocument();
         // Animation might take time to exit or re-render, but our mock removes it immediately if logic is correct
-        expect(screen.queryByText('Drop files to attach')).not.toBeInTheDocument();
+        await waitFor(() => {
+            expect(screen.queryByText('Drop files to attach')).not.toBeInTheDocument();
+        });
         expect(dropZone).not.toHaveClass('ring-4');
 
         // Drop

--- a/src/core/components/SidebarNavigation.test.tsx
+++ b/src/core/components/SidebarNavigation.test.tsx
@@ -49,18 +49,24 @@ describe('Sidebar Navigation Integration', () => {
     const mockInitializeAuth = vi.fn();
     const mockInitializeHistory = vi.fn();
     const mockLoadProjects = vi.fn();
+    const mockToggleSidebar = vi.fn();
+
+    const buildStoreState = (overrides: Record<string, unknown> = {}) => ({
+        currentModule: 'dashboard',
+        setModule: mockSetModule,
+        isSidebarOpen: true,
+        toggleSidebar: mockToggleSidebar,
+        initializeAuth: mockInitializeAuth,
+        initializeHistory: mockInitializeHistory,
+        loadProjects: mockLoadProjects,
+        isAuthReady: true,
+        isAuthenticated: true,
+        ...overrides,
+    });
 
     beforeEach(() => {
         vi.clearAllMocks();
-        (useStore as any).mockReturnValue({
-            currentModule: 'dashboard',
-            setModule: mockSetModule,
-            isSidebarOpen: true,
-            toggleSidebar: vi.fn(),
-            initializeAuth: mockInitializeAuth,
-            initializeHistory: mockInitializeHistory,
-            loadProjects: mockLoadProjects,
-        });
+        (useStore as any).mockReturnValue(buildStoreState());
         // Mock setState on the store object itself for App.tsx direct usage
         (useStore as any).setState = vi.fn();
     });
@@ -95,7 +101,7 @@ describe('Sidebar Navigation Integration', () => {
 
     it('renders correct dashboard for Brand Manager', async () => {
         (useStore as any).mockReturnValue({
-            ...useStore(),
+            ...buildStoreState(),
             currentModule: 'brand',
         });
 
@@ -108,7 +114,7 @@ describe('Sidebar Navigation Integration', () => {
 
     it('renders correct dashboard for Campaign Manager', async () => {
         (useStore as any).mockReturnValue({
-            ...useStore(),
+            ...buildStoreState(),
             currentModule: 'campaign',
         });
 
@@ -121,7 +127,7 @@ describe('Sidebar Navigation Integration', () => {
 
     it('renders correct dashboard for Publicist', async () => {
         (useStore as any).mockReturnValue({
-            ...useStore(),
+            ...buildStoreState(),
             currentModule: 'publicist',
         });
 
@@ -134,7 +140,7 @@ describe('Sidebar Navigation Integration', () => {
 
     it('renders correct dashboard for Publishing', async () => {
         (useStore as any).mockReturnValue({
-            ...useStore(),
+            ...buildStoreState(),
             currentModule: 'publishing',
         });
 
@@ -147,7 +153,7 @@ describe('Sidebar Navigation Integration', () => {
 
     it('renders correct dashboard for Finance', async () => {
         (useStore as any).mockReturnValue({
-            ...useStore(),
+            ...buildStoreState(),
             currentModule: 'finance',
         });
 
@@ -160,7 +166,7 @@ describe('Sidebar Navigation Integration', () => {
 
     it('renders correct dashboard for Licensing', async () => {
         (useStore as any).mockReturnValue({
-            ...useStore(),
+            ...buildStoreState(),
             currentModule: 'licensing',
         });
 
@@ -174,14 +180,12 @@ describe('Sidebar Navigation Integration', () => {
     it('renders user profile and logout button', () => {
         const mockLogout = vi.fn();
         (useStore as any).mockReturnValue({
-            currentModule: 'dashboard',
-            setModule: mockSetModule,
-            isSidebarOpen: true,
+            ...buildStoreState(),
             user: {
                 displayName: 'Test User',
                 email: 'test@example.com'
             },
-            logout: mockLogout
+            logout: mockLogout,
         });
 
         render(<Sidebar />);


### PR DESCRIPTION
### Motivation
- Tests were flaky because the app rendering depended on global auth state that wasn't consistently mocked in sidebar integration tests.
- The `CommandBar` drag-and-drop test was timing-sensitive and could fail due to animation/overlay timing.
- Centralizing the mocked store state reduces duplication and makes module-specific overrides simpler to reason about.
- Make drag overlay assertions resilient to async UI changes to reduce test flakiness.

### Description
- Added a `buildStoreState` helper and a `mockToggleSidebar` to `src/core/components/SidebarNavigation.test.tsx` and used it as the single source of mocked store state including `isAuthReady` and `isAuthenticated`.
- Replaced multiple inline `useStore` mock return objects with calls to `buildStoreState()` when overriding `currentModule` for different dashboard rendering tests.
- Converted the drag-and-drop test in `src/core/components/CommandBar.test.tsx` to an `async` test and replaced a `waitFor` assertion with `await screen.findByText('Drop files to attach')` for more reliable overlay detection, while keeping a `waitFor` for removal of the overlay.
- Updated tests to mock `toggleSidebar` and kept `useStore.setState` mocked for `App` usage to ensure consistent test behavior.

### Testing
- No automated tests were executed as part of this change.
- To validate locally, run the test suite with `npm run test` which mirrors the CI job that runs on push/PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694adef87eb0832e992fdbcbf94dff50)