### PR TITLE
fix: SSG build errors and StorageService fallback query bug

### DIFF
--- a/forge.config.cjs
+++ b/forge.config.cjs
@@ -69,7 +69,11 @@ module.exports = {
       teamId: process.env.APPLE_TEAM_ID
     } : undefined,
   },
-  rebuildConfig: {},
+  rebuildConfig: {
+    // Skip rebuilding canvas - fabric.js uses browser Canvas API in Electron renderer
+    // canvas is only needed for server-side rendering, not in browser context
+    onlyModules: []  // Empty array means don't rebuild any native modules
+  },
   makers: [
     {
       name: '@electron-forge/maker-squirrel',

--- a/landing-page/app/(auth)/verify-email/page.tsx
+++ b/landing-page/app/(auth)/verify-email/page.tsx
@@ -25,6 +25,11 @@ function VerifyEmailContent() {
     useEffect(() => {
         async function verify() {
             if (!oobCode) return; // Should be handled by initial state, but safe guard
+            if (!auth) {
+                setStatus('error');
+                setError('Authentication service not available');
+                return;
+            }
 
             try {
                 await applyActionCode(auth, oobCode);

--- a/landing-page/app/components/auth/AuthProvider.tsx
+++ b/landing-page/app/components/auth/AuthProvider.tsx
@@ -23,10 +23,16 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     const [loading, setLoading] = useState(true);
 
     useEffect(() => {
+        // Skip auth listener if Firebase not initialized (SSR/build time)
+        if (!auth) {
+            setLoading(false);
+            return;
+        }
+
         const unsubscribe = onAuthStateChanged(auth, async (firebaseUser) => {
             setUser(firebaseUser);
 
-            if (firebaseUser) {
+            if (firebaseUser && db) {
                 // Fetch user profile
                 try {
                     const userDoc = await getDoc(doc(db, 'users', firebaseUser.uid));

--- a/landing-page/app/components/auth/SignupForm.tsx
+++ b/landing-page/app/components/auth/SignupForm.tsx
@@ -19,6 +19,9 @@ export default function SignupForm() {
 
 
     useEffect(() => {
+        // Skip if Firebase not initialized (SSR/build time)
+        if (!auth) return;
+
         // Also check if user is ALREADY authenticated (loop protection)
         const unsubscribe = onAuthStateChanged(auth, (user) => {
             if (user) {

--- a/landing-page/app/lib/auth.ts
+++ b/landing-page/app/lib/auth.ts
@@ -20,6 +20,7 @@ const STUDIO_URL = process.env.NEXT_PUBLIC_STUDIO_URL || (process.env.NODE_ENV =
  * Sign in with email and password
  */
 export async function signInWithEmail(email: string, password: string) {
+  if (!auth) throw new Error('Firebase Auth not initialized');
   const result = await signInWithEmailAndPassword(auth, email, password);
   await updateLastLogin(result.user.uid);
   return result.user;
@@ -29,6 +30,7 @@ export async function signInWithEmail(email: string, password: string) {
  * Create new account with email and password
  */
 export async function signUpWithEmail(email: string, password: string, displayName: string) {
+  if (!auth) throw new Error('Firebase Auth not initialized');
   const result = await createUserWithEmailAndPassword(auth, email, password);
 
   // Update display name
@@ -50,6 +52,7 @@ export async function signUpWithEmail(email: string, password: string, displayNa
  * Sign out current user
  */
 export async function logOut() {
+  if (!auth) throw new Error('Firebase Auth not initialized');
   await signOut(auth);
 }
 
@@ -57,6 +60,7 @@ export async function logOut() {
  * Send password reset email
  */
 export async function resetPassword(email: string) {
+  if (!auth) throw new Error('Firebase Auth not initialized');
   await sendPasswordResetEmail(auth, email);
 }
 
@@ -64,6 +68,7 @@ export async function resetPassword(email: string) {
  * Create user document in Firestore
  */
 async function createUserDocument(user: User, displayName?: string) {
+  if (!db) throw new Error('Firestore not initialized');
   const userRef = doc(db, 'users', user.uid);
   await setDoc(userRef, {
     uid: user.uid,
@@ -80,6 +85,7 @@ async function createUserDocument(user: User, displayName?: string) {
  * Update last login timestamp
  */
 async function updateLastLogin(uid: string) {
+  if (!db) throw new Error('Firestore not initialized');
   const userRef = doc(db, 'users', uid);
   await setDoc(userRef, { lastLoginAt: serverTimestamp() }, { merge: true });
 }

--- a/landing-page/app/lib/firebase.ts
+++ b/landing-page/app/lib/firebase.ts
@@ -1,6 +1,6 @@
-import { initializeApp, getApps } from 'firebase/app';
-import { getAuth } from 'firebase/auth';
-import { getFirestore } from 'firebase/firestore';
+import { initializeApp, getApps, type FirebaseApp } from 'firebase/app';
+import { getAuth, type Auth } from 'firebase/auth';
+import { getFirestore, type Firestore } from 'firebase/firestore';
 
 const firebaseConfig = {
   apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
@@ -13,9 +13,17 @@ const firebaseConfig = {
   measurementId: "G-7WW3HEHFTF"
 };
 
-// Initialize Firebase (prevent duplicate initialization in dev)
-const app = getApps().length === 0 ? initializeApp(firebaseConfig) : getApps()[0];
+// Only initialize Firebase on the client side to prevent SSG build errors
+// when NEXT_PUBLIC_FIREBASE_API_KEY is not available during static export
+let app: FirebaseApp | undefined;
+let auth: Auth | undefined;
+let db: Firestore | undefined;
 
-export const auth = getAuth(app);
-export const db = getFirestore(app);
+if (typeof window !== 'undefined' && firebaseConfig.apiKey) {
+  app = getApps().length === 0 ? initializeApp(firebaseConfig) : getApps()[0];
+  auth = getAuth(app);
+  db = getFirestore(app);
+}
+
+export { auth, db };
 export default app;

--- a/landing-page/app/login-bridge/page.tsx
+++ b/landing-page/app/login-bridge/page.tsx
@@ -9,6 +9,11 @@ export default function LoginBridge() {
     const [error, setError] = useState<string | null>(null);
 
     useEffect(() => {
+        if (!app) {
+            setError('Firebase not initialized');
+            setStatus('error');
+            return;
+        }
         const auth = getAuth(app);
 
         // Check if already logged in - but we need to force a fresh sign-in to get OAuth tokens
@@ -42,6 +47,7 @@ export default function LoginBridge() {
         setError(null);
 
         try {
+            if (!app) throw new Error('Firebase not initialized');
             const auth = getAuth(app);
             const provider = new GoogleAuthProvider();
             provider.addScope('profile');

--- a/src/services/StorageService.ts
+++ b/src/services/StorageService.ts
@@ -119,7 +119,8 @@ class StorageServiceImpl extends FirestoreService<HistoryItem> {
                     const { auth } = await import('./firebase');
                     const constraints = [where('orgId', '==', orgId), limit(limitCount)];
 
-                    if (orgId === 'org-default' || orgId === 'personal') {
+                    // Only filter by userId for personal org (matches primary query path logic)
+                    if (orgId === 'personal') {
                         if (auth.currentUser) {
                             constraints.push(where('userId', '==', auth.currentUser.uid));
                         } else {


### PR DESCRIPTION
Fixes #58 - StorageService fallback query incorrectly filtered by userId
for 'org-default' workspaces. Now only filters for 'personal' org.

Landing Page (SSG Fix):
- Make Firebase initialization client-side only to prevent build errors
  when NEXT_PUBLIC_FIREBASE_API_KEY is missing in CI
- Add null checks for auth/db in all Firebase-dependent components
- Affected: firebase.ts, auth.ts, AuthProvider, SignupForm, LoginBridge,
  verify-email page

Electron Build (node-gyp Fix):
- Configure rebuildConfig.onlyModules=[] to skip native module rebuilds
- Fixes build failure when project path contains spaces (e.g. "X SSD 2025")
- fabric.js uses browser Canvas API in Electron, so canvas rebuild is
  unnecessary

Documentation:
- Add section 13.7 to CLAUDE.md documenting the node-gyp spaced path fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added troubleshooting guide for Electron build failures with spaced project paths.

* **Bug Fixes**
  * Improved error handling for Firebase initialization in authentication flows.
  * Enhanced robustness by adding initialization checks to prevent runtime failures.
  * Refined storage query filtering for personal organizations.

* **Chores**
  * Updated native module rebuild configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->