### PR TITLE
refactor(finance): remove unused `--storage-path` argument from water…

### DIFF
--- a/execution/finance/waterfall_payout.py
+++ b/execution/finance/waterfall_payout.py
@@ -99,7 +99,6 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(description="Waterfall Payout Calculator")
     parser.add_argument("payload", help="JSON payload for the calculation")
-    parser.add_argument("--storage-path", help="Path to the data store directory (unused but for consistency)")
 
     args = parser.parse_args()
 

--- a/packages/main/src/handlers/distribution.ts
+++ b/packages/main/src/handlers/distribution.ts
@@ -208,11 +208,8 @@ export const setupDistributionHandlers = () => {
     ipcMain.handle('distribution:execute-waterfall', async (event, data: unknown) => {
         try {
             validateSender(event);
-            const storagePath = getStoragePath();
             const report = await AgentSupervisor.execute('finance', 'waterfall_payout.py', [
-                JSON.stringify(data),
-                '--storage-path',
-                storagePath
+                JSON.stringify(data)
             ], { timeoutMs: 60000 }, undefined, {}, [0]); // Redact JSON data
             return { success: true, report };
         } catch (error) {


### PR DESCRIPTION
…fall_payout.py

Removed the unused `--storage-path` CLI argument from `execution/finance/waterfall_payout.py` and updated its caller in `packages/main/src/handlers/distribution.ts` to stop passing the argument and remove the unneeded local `storagePath` variable. Tests pass successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the `--storage-path` command-line argument from waterfall payout operations, simplifying the execution process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->