### PR TITLE
🧹 [Code Health Improvement] Remove unused --storage-path argument from xsd_validator.py

### DIFF
--- a/execution/distribution/xsd_validator.py
+++ b/execution/distribution/xsd_validator.py
@@ -434,7 +434,6 @@ if __name__ == "__main__":
     )
     parser.add_argument("xml_input", help="XML file path or XML string")
     parser.add_argument("--xsd", help="Path to DDEX ERN XSD schema file")
-    parser.add_argument("--storage-path", help="Path for persistence (unused, for consistency)")
 
     args = parser.parse_args()
 


### PR DESCRIPTION
🎯 **What:** Removed the explicit addition of the unused `--storage-path` argument from the `argparse` configuration in `execution/distribution/xsd_validator.py`.
💡 **Why:** The argument was marked as `(unused, for consistency)` and removing it improves code clarity and maintains code health.
✅ **Verification:** Verified via `verify_all_scripts.py` and local manual testing (`python execution/distribution/xsd_validator.py -h`).
✨ **Result:** A slightly cleaner and more focused `xsd_validator.py` script.

---
*PR created automatically by Jules for task [1853293650359047786](https://jules.google.com/task/1853293650359047786) started by @the-walking-agency-det*