### PR TITLE
🧹 Remove unused props assignment in BoardroomModule.test.tsx

### DIFF
--- a/packages/renderer/src/modules/boardroom/BoardroomModule.test.tsx
+++ b/packages/renderer/src/modules/boardroom/BoardroomModule.test.tsx
@@ -39,8 +39,7 @@ vi.mock('@/core/components/chat/ChatMessage', () => ({
 vi.mock('@/components/ui/tooltip', () => ({
     TooltipProvider: ({ children }: React.PropsWithChildren) => <>{children}</>,
     Tooltip: ({ children }: React.PropsWithChildren) => <>{children}</>,
-    TooltipTrigger: React.forwardRef(({ children, ...props }: React.PropsWithChildren<{ asChild?: boolean }>, _ref: React.Ref<HTMLDivElement>) => {
-        const _unused = props;
+    TooltipTrigger: React.forwardRef(({ children }: React.PropsWithChildren<{ asChild?: boolean }>, _ref: React.Ref<HTMLDivElement>) => {
         return <div>{children}</div>;
     }),
     TooltipContent: ({ children }: React.PropsWithChildren) => <div>{children}</div>,


### PR DESCRIPTION
🎯 **What:** Removed unused `props` destructuring and `_unused` assignment in `TooltipTrigger` mock in `packages/renderer/src/modules/boardroom/BoardroomModule.test.tsx`.

💡 **Why:** Cleans up code by removing unneeded variables, eliminating a linting/health issue and simplifying the test setup.

✅ **Verification:**
- Ran `npx vitest packages/renderer/src/modules/boardroom/BoardroomModule.test.tsx` (passes)
- Ran full `npm test` suite (passes)
- Ran `npm run typecheck` (passes)
- Confirmed logic behavior remains unaffected (as this is a test mock file).

✨ **Result:** Improved test code clarity and overall health of the codebase.

---
*PR created automatically by Jules for task [6976308890834184075](https://jules.google.com/task/6976308890834184075) started by @the-walking-agency-det*