### PR TITLE
🔒 Security: Enforce encryption for keychain storage

### DIFF
--- a/packages/main/src/services/CredentialService.ts
+++ b/packages/main/src/services/CredentialService.ts
@@ -28,8 +28,8 @@ export class CredentialService {
                 const encryptedBuffer = safeStorage.encryptString(secretSerialized);
                 payloadToStore = encryptedBuffer.toString('base64');
             } else {
-                console.warn('[CredentialService] safeStorage not available, falling back to plain keychain storage');
-                payloadToStore = secretSerialized;
+                console.error('[CredentialService] safeStorage not available, refusing to store credentials in plaintext');
+                throw new Error('Encryption is not available. Credentials cannot be stored securely.');
             }
 
             await keytar.setPassword(SERVICE_NAME, distributorId, payloadToStore);


### PR DESCRIPTION
🎯 **What:** Refactored CredentialService to refuse saving credentials in plaintext when safeStorage is unavailable.
⚠️ **Risk:** If safeStorage encryption is unavailable on the host system, the application falls back to saving sensitive credentials (like API keys) in plaintext in the OS keychain, introducing a severe security vulnerability.
🛡️ **Solution:** Updated the `saveCredentials` fallback to throw an error and log securely, rather than saving in plaintext, enforcing an encryption-only policy for credentials.

---
*PR created automatically by Jules for task [8013751078457461396](https://jules.google.com/task/8013751078457461396) started by @the-walking-agency-det*