### PR TITLE
🧹 Remove unused props assignment in TooltipTrigger mock

### DIFF
--- a/packages/renderer/src/modules/boardroom/BoardroomModule.test.tsx
+++ b/packages/renderer/src/modules/boardroom/BoardroomModule.test.tsx
@@ -39,8 +39,7 @@ vi.mock('@/core/components/chat/ChatMessage', () => ({
 vi.mock('@/components/ui/tooltip', () => ({
     TooltipProvider: ({ children }: React.PropsWithChildren) => <>{children}</>,
     Tooltip: ({ children }: React.PropsWithChildren) => <>{children}</>,
-    TooltipTrigger: React.forwardRef(({ children, ...props }: React.PropsWithChildren<{ asChild?: boolean }>, _ref: React.Ref<HTMLDivElement>) => {
-        const _unused = props;
+    TooltipTrigger: React.forwardRef(({ children }: React.PropsWithChildren<{ asChild?: boolean }>, _ref: React.Ref<HTMLDivElement>) => {
         return <div>{children}</div>;
     }),
     TooltipContent: ({ children }: React.PropsWithChildren) => <div>{children}</div>,


### PR DESCRIPTION
🎯 **What:** Removed the unused `...props` rest parameter and the subsequent `const _unused = props;` assignment from the `TooltipTrigger` mock in `BoardroomModule.test.tsx`.
💡 **Why:** Improves code health by eliminating dead code and unnecessary variable assignments, making the test mock cleaner and more readable.
✅ **Verification:** Ran `npm run lint` to confirm no new linting errors and `npm run test` to ensure the `BoardroomModule` tests still pass successfully.
✨ **Result:** Cleaner, more maintainable test code without changing functionality.

---
*PR created automatically by Jules for task [2201453377558585172](https://jules.google.com/task/2201453377558585172) started by @the-walking-agency-det*