### PR TITLE
🧪 test(security): explicit error path test coverage for generateSecureHex

### DIFF
--- a/packages/renderer/src/utils/security.test.ts
+++ b/packages/renderer/src/utils/security.test.ts
@@ -35,7 +35,20 @@ describe('Security Utilities', () => {
     it('should throw an error if crypto.getRandomValues is not available', () => {
       // Temporarily mock crypto to not have getRandomValues
       Object.defineProperty(globalThis, 'crypto', {
-        value: {},
+        value: { getRandomValues: undefined },
+        writable: true,
+        configurable: true,
+      });
+
+      expect(() => generateSecureHex(10)).toThrow(
+        '[Security] crypto.getRandomValues is required but not available. Cannot generate secure random values.'
+      );
+    });
+
+    it('should throw an error if crypto is null', () => {
+      // Temporarily mock crypto to be null
+      Object.defineProperty(globalThis, 'crypto', {
+        value: null,
         writable: true,
         configurable: true,
       });


### PR DESCRIPTION
🧪 **What:** The testing gap addressed involves adding explicit test cases for `generateSecureHex` in `packages/renderer/src/utils/security.test.ts` where `globalThis.crypto`'s `getRandomValues` method is set to `undefined`, or when `crypto` itself is `null`.

📊 **Coverage:** The tests now deterministically cover the exact `if (!crypto || !crypto.getRandomValues)` conditional blocks, effectively handling `undefined` and `null` values as explicitly mocked environment properties.

✨ **Result:** Test coverage for this error path is demonstrably complete and ensures proper function failure behavior when cryptographically secure random number generation APIs are unavailable. No regressions were introduced across the monorepo workspace.

---
*PR created automatically by Jules for task [8502805636753918595](https://jules.google.com/task/8502805636753918595) started by @the-walking-agency-det*