### PR TITLE
🧹 [code health improvement] Remove unused --storage-path argument

### DIFF
--- a/execution/distribution/deliver_apple.py
+++ b/execution/distribution/deliver_apple.py
@@ -299,7 +299,6 @@ if __name__ == "__main__":
     parser.add_argument("--apple-id", help="Apple ID (overrides env var)")
     parser.add_argument("--password", help="App-specific password (overrides env var)")
     parser.add_argument("--provider-id", help="Provider short name (overrides env var)")
-    parser.add_argument("--storage-path", help="Path for logs (unused, for consistency)")
 
     args = parser.parse_args()
 

--- a/execution/distribution/package_itmsp.py
+++ b/execution/distribution/package_itmsp.py
@@ -137,7 +137,6 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Apple ITMSP Bundle Packager")
     parser.add_argument("release_id", help="The ID of the release")
     parser.add_argument("staging_path", help="Path to the staged assets and metadata")
-    parser.add_argument("--storage-path", help="Path to the data store directory (unused but for consistency)")
 
     args = parser.parse_args()
 

--- a/execution/distribution/package_spotify.py
+++ b/execution/distribution/package_spotify.py
@@ -274,7 +274,6 @@ if __name__ == "__main__":
     parser.add_argument("staging_path", help="Path to staged assets and metadata")
     parser.add_argument("--output", help="Output directory for the package")
     parser.add_argument("--batch-id", help="Optional batch identifier")
-    parser.add_argument("--storage-path", help="Path for logs (unused, for consistency)")
 
     args = parser.parse_args()
 

--- a/execution/distribution/qc_validator.py
+++ b/execution/distribution/qc_validator.py
@@ -157,7 +157,6 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(description="Distribution QC Validator")
     parser.add_argument("payload", help="JSON payload containing metadata to validate")
-    parser.add_argument("--storage-path", help="Path to the data store directory (unused but for consistency)")
 
     args = parser.parse_args()
 


### PR DESCRIPTION
🎯 **What:** Removed the unused `--storage-path` argument from `execution/distribution/qc_validator.py`, `package_spotify.py`, `package_itmsp.py`, and `deliver_apple.py`.
💡 **Why:** The argument was explicitly documented as `unused but for consistency` and parsing it was dead code. Removing it improves maintainability and simplifies the argument parser definitions.
✅ **Verification:** I ran `python execution/verify_all_scripts.py` to ensure all distribution integration tests passed. I also ran `npm test -- --run` and `npm run typecheck` across the workspace to ensure zero regressions elsewhere.
✨ **Result:** Dead code arguments are eliminated, reducing surface area and potential confusion for callers.

---
*PR created automatically by Jules for task [5220156449847792847](https://jules.google.com/task/5220156449847792847) started by @the-walking-agency-det*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the `--storage-path` command-line argument from distribution and packaging tools, including Apple delivery, iTunes package, Spotify package, and quality control validation utilities. These scripts will now reject invocations using the `--storage-path` flag. Any automation or deployment scripts relying on this argument will require updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->