### PR TITLE
🧪 add error path test for generateSecureHex

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,4 @@ dist/
 packages/shared/dist/
 electron/
 functions/
+coverage/

--- a/packages/renderer/src/utils/security.test.ts
+++ b/packages/renderer/src/utils/security.test.ts
@@ -45,6 +45,23 @@ describe('Security Utilities', () => {
       );
     });
 
+    it('should throw an error if crypto is deleted from globalThis', () => {
+      // Temporarily mock globalThis.crypto to not exist using Object.defineProperty
+      // which allows the existing afterEach hook to properly restore it.
+      Object.defineProperty(globalThis, 'crypto', {
+        value: undefined, // this effectively simulates the property being missing
+        writable: true,
+        configurable: true,
+      });
+
+      // To fully simulate deletion and ensure the global proxy handles it as missing:
+      delete (globalThis as any).crypto;
+
+      expect(() => generateSecureHex(10)).toThrow(
+        '[Security] crypto.getRandomValues is required but not available. Cannot generate secure random values.'
+      );
+    });
+
     it('should throw an error if crypto is null', () => {
       // Temporarily mock crypto to be null
       Object.defineProperty(globalThis, 'crypto', {


### PR DESCRIPTION
🎯 **What:** The testing gap for handling missing `globalThis.crypto` API was addressed. 
📊 **Coverage:** A new explicit scenario where `crypto` is genuinely deleted from `globalThis` is now tested.
✨ **Result:** Test suite is now more robust by avoiding false positives on missing globals, while properly utilizing test hooks to ensure test pollution doesn't occur.

---
*PR created automatically by Jules for task [7265813519322817885](https://jules.google.com/task/7265813519322817885) started by @the-walking-agency-det*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced security testing to cover missing crypto scenarios.

* **Chores**
  * Updated build configuration to exclude coverage artifacts from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->