### PR TITLE
Fix BUG-005 by making Escape force-close UnifiedCommandMenu during the capture phase

### DIFF
--- a/packages/renderer/src/components/shared/UnifiedCommandMenu.tsx
+++ b/packages/renderer/src/components/shared/UnifiedCommandMenu.tsx
@@ -34,8 +34,8 @@ export function UnifiedCommandMenu() {
             }
         };
 
-        document.addEventListener('keydown', down);
-        return () => document.removeEventListener('keydown', down);
+        document.addEventListener('keydown', down, { capture: true });
+        return () => document.removeEventListener('keydown', down, { capture: true });
     }, [isCommandMenuOpen, setCommandMenuOpen]);
 
     // Run a command and close the menu


### PR DESCRIPTION
The bug "BUG-005" described the command menu failing to close when pressing Escape rapidly, likely because child elements inside the command menu component (like `cmdk`) might be stopping the event propagation before it reaches the `document.addEventListener`. To fix this, I added `{ capture: true }` to both `document.addEventListener` and `document.removeEventListener` in `UnifiedCommandMenu.tsx`. This causes the event listener to catch the keydown event during the *capture* phase instead of the *bubble* phase, intercepting it before child components can stop its propagation, ensuring the menu reliably force-closes.

---
*PR created automatically by Jules for task [13633023757339292329](https://jules.google.com/task/13633023757339292329) started by @the-walking-agency-det*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard event handling in the command menu to ensure consistent and reliable processing of keyboard shortcuts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->