### PR TITLE
Fix rapid sidebar toggle glitches

### DIFF
--- a/packages/renderer/src/core/store/slices/appSlice.ts
+++ b/packages/renderer/src/core/store/slices/appSlice.ts
@@ -50,6 +50,8 @@ export interface AppSlice {
     setHasUnsavedChanges: (hasUnsaved: boolean) => void;
     /** @internal Debounce tracker for toggleRightPanel */
     _lastRightPanelToggle?: number;
+    /** @internal Debounce tracker for toggleSidebar */
+    _lastSidebarToggle?: number;
 }
 
 export const createAppSlice: StateCreator<AppSlice> = (set, get) => ({
@@ -131,13 +133,19 @@ export const createAppSlice: StateCreator<AppSlice> = (set, get) => ({
     isSidebarOpen: typeof window !== 'undefined' ? localStorage.getItem('indiiOS_sidebarOpen') !== 'false' : true,
     isRightPanelOpen: false,
     rightPanelTab: 'context',
-    toggleSidebar: () => set((state) => {
+    toggleSidebar: () => {
+        const now = Date.now();
+        const state = get();
+        if (state._lastSidebarToggle && now - state._lastSidebarToggle < 200) {
+            return;
+        }
+
         const newState = !state.isSidebarOpen;
         if (typeof window !== 'undefined') {
             localStorage.setItem('indiiOS_sidebarOpen', String(newState));
         }
-        return { isSidebarOpen: newState };
-    }),
+        set({ isSidebarOpen: newState, _lastSidebarToggle: now });
+    },
     toggleRightPanel: () => {
         // BUG-006 FIX: Debounce rapid toggle clicks.
         // The AnimatePresence mode="wait" in RightPanel can get stuck


### PR DESCRIPTION
Added a debounce mechanism to `toggleSidebar` in `appSlice.ts` to prevent UI glitches during spring animations when toggled rapidly. This mimics the existing debounce logic in `toggleRightPanel`.

---
*PR created automatically by Jules for task [7291632070837177727](https://jules.google.com/task/7291632070837177727) started by @the-walking-agency-det*