### PR TITLE
Debounce rapid toggle clicks on toggleSidebar

### DIFF
--- a/packages/renderer/src/core/store/slices/appSlice.ts
+++ b/packages/renderer/src/core/store/slices/appSlice.ts
@@ -48,6 +48,8 @@ export interface AppSlice {
     setCommandMenuOpen: (open: boolean) => void;
     hasUnsavedChanges: boolean;
     setHasUnsavedChanges: (hasUnsaved: boolean) => void;
+    /** @internal Debounce tracker for toggleSidebar */
+    _lastSidebarToggle?: number;
     /** @internal Debounce tracker for toggleRightPanel */
     _lastRightPanelToggle?: number;
 }
@@ -131,13 +133,18 @@ export const createAppSlice: StateCreator<AppSlice> = (set, get) => ({
     isSidebarOpen: typeof window !== 'undefined' ? localStorage.getItem('indiiOS_sidebarOpen') !== 'false' : true,
     isRightPanelOpen: false,
     rightPanelTab: 'context',
-    toggleSidebar: () => set((state) => {
+    toggleSidebar: () => {
+        const now = Date.now();
+        const state = get();
+        if (state._lastSidebarToggle && now - state._lastSidebarToggle < 200) {
+            return; // Ignore rapid-fire toggles
+        }
         const newState = !state.isSidebarOpen;
         if (typeof window !== 'undefined') {
             localStorage.setItem('indiiOS_sidebarOpen', String(newState));
         }
-        return { isSidebarOpen: newState };
-    }),
+        set({ isSidebarOpen: newState, _lastSidebarToggle: now });
+    },
     toggleRightPanel: () => {
         // BUG-006 FIX: Debounce rapid toggle clicks.
         // The AnimatePresence mode="wait" in RightPanel can get stuck


### PR DESCRIPTION
Add `_lastSidebarToggle` state to `appSlice` and enforce a 200ms debounce window on `toggleSidebar`, mirroring the behavior of `toggleRightPanel` to fix BUG-006 where rapid toggles get stuck.

---
*PR created automatically by Jules for task [10282229912824616031](https://jules.google.com/task/10282229912824616031) started by @the-walking-agency-det*