### PR TITLE
fix(appSlice): debounce rapid sidebar toggle clicks

### DIFF
--- a/packages/renderer/src/core/store/slices/__tests__/appSlice.test.ts
+++ b/packages/renderer/src/core/store/slices/__tests__/appSlice.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { create } from 'zustand';
+import { createAppSlice, AppSlice } from '../appSlice';
+
+describe('appSlice', () => {
+    let useStore: any;
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+        useStore = create<AppSlice>((...args) => ({
+            ...createAppSlice(...args),
+        }));
+    });
+
+    afterEach(() => {
+        vi.runOnlyPendingTimers();
+        vi.useRealTimers();
+    });
+
+
+    describe('toggleSidebar', () => {
+        it('should toggle sidebar state', () => {
+            const store = useStore.getState();
+            expect(store.isSidebarOpen).toBe(true); // Default is true usually, or from localStorage
+
+            useStore.getState().toggleSidebar();
+
+            expect(useStore.getState().isSidebarOpen).toBe(!store.isSidebarOpen);
+            expect(useStore.getState()._lastSidebarToggle).toBeDefined();
+        });
+
+        it('should debounce rapid toggles', () => {
+            const initialState = useStore.getState().isSidebarOpen;
+
+            // First toggle
+            useStore.getState().toggleSidebar();
+            expect(useStore.getState().isSidebarOpen).toBe(!initialState);
+
+            // Advance time slightly (under 200ms)
+            vi.advanceTimersByTime(100);
+
+            // Second toggle (should be ignored)
+            useStore.getState().toggleSidebar();
+            expect(useStore.getState().isSidebarOpen).toBe(!initialState); // Still flipped state
+
+            // Advance time past debounce window
+            vi.advanceTimersByTime(150); // Total 250ms
+
+            // Third toggle (should work)
+            useStore.getState().toggleSidebar();
+            expect(useStore.getState().isSidebarOpen).toBe(initialState);
+        });
+    });
+
+    describe('toggleRightPanel', () => {
+        it('should toggle right panel state', () => {
+            const store = useStore.getState();
+            expect(store.isRightPanelOpen).toBe(false);
+
+            useStore.getState().toggleRightPanel();
+
+            expect(useStore.getState().isRightPanelOpen).toBe(true);
+            expect(useStore.getState()._lastRightPanelToggle).toBeDefined();
+        });
+
+        it('should debounce rapid toggles', () => {
+            // First toggle
+            useStore.getState().toggleRightPanel();
+            expect(useStore.getState().isRightPanelOpen).toBe(true);
+
+            // Advance time slightly (under 200ms)
+            vi.advanceTimersByTime(100);
+
+            // Second toggle (should be ignored)
+            useStore.getState().toggleRightPanel();
+            expect(useStore.getState().isRightPanelOpen).toBe(true); // Still true
+
+            // Advance time past debounce window
+            vi.advanceTimersByTime(150); // Total 250ms
+
+            // Third toggle (should work)
+            useStore.getState().toggleRightPanel();
+            expect(useStore.getState().isRightPanelOpen).toBe(false);
+        });
+    });
+});

--- a/packages/renderer/src/core/store/slices/appSlice.ts
+++ b/packages/renderer/src/core/store/slices/appSlice.ts
@@ -50,6 +50,8 @@ export interface AppSlice {
     setHasUnsavedChanges: (hasUnsaved: boolean) => void;
     /** @internal Debounce tracker for toggleRightPanel */
     _lastRightPanelToggle?: number;
+    /** @internal Debounce tracker for toggleSidebar */
+    _lastSidebarToggle?: number;
 }
 
 export const createAppSlice: StateCreator<AppSlice> = (set, get) => ({
@@ -131,13 +133,18 @@ export const createAppSlice: StateCreator<AppSlice> = (set, get) => ({
     isSidebarOpen: typeof window !== 'undefined' ? localStorage.getItem('indiiOS_sidebarOpen') !== 'false' : true,
     isRightPanelOpen: false,
     rightPanelTab: 'context',
-    toggleSidebar: () => set((state) => {
+    toggleSidebar: () => {
+        const now = Date.now();
+        const state = get();
+        if (state._lastSidebarToggle && now - state._lastSidebarToggle < 200) {
+            return; // Ignore rapid-fire toggles
+        }
         const newState = !state.isSidebarOpen;
         if (typeof window !== 'undefined') {
             localStorage.setItem('indiiOS_sidebarOpen', String(newState));
         }
-        return { isSidebarOpen: newState };
-    }),
+        set({ isSidebarOpen: newState, _lastSidebarToggle: now });
+    },
     toggleRightPanel: () => {
         // BUG-006 FIX: Debounce rapid toggle clicks.
         // The AnimatePresence mode="wait" in RightPanel can get stuck


### PR DESCRIPTION
Added debounce logic to `toggleSidebar` in `appSlice.ts` to prevent rapid toggle clicks from triggering visual/animation bugs, similar to what was previously done for `toggleRightPanel`. Added corresponding unit tests in `appSlice.test.ts`.

---
*PR created automatically by Jules for task [2763950868211660991](https://jules.google.com/task/2763950868211660991) started by @the-walking-agency-det*