### PR TITLE
🧹 refactor(identity): extract magic numbers to constants in IdentifierService

### DIFF
--- a/packages/renderer/src/services/identity/IdentifierService.ts
+++ b/packages/renderer/src/services/identity/IdentifierService.ts
@@ -14,6 +14,9 @@ export class IdentifierService {
     // In a real system, this would be dynamic per user or org
     private static readonly DEFAULT_COUNTRY_CODE = 'US';
     private static readonly DEFAULT_REGISTRANT_CODE = 'QY1'; // Example Registrant
+    private static readonly DEFAULT_ISRC_LAST_YEAR = 26;
+    private static readonly DEFAULT_ISRC_START_SEQUENCE = 100;
+    private static readonly DEFAULT_UPC_START_SEQUENCE = 10000000000;
 
     /**
      * Fetch and increment the next sequence number from Firestore.
@@ -28,8 +31,8 @@ export class IdentifierService {
             if (!seqDoc.exists()) {
                 // Initialize if not exists
                 const initialData = {
-                    isrc: { lastYear: year || 26, sequence: 100 }, // Start at 100 for padding
-                    upc: { sequence: 10000000000 } // 11 digits start
+                    isrc: { lastYear: year || IdentifierService.DEFAULT_ISRC_LAST_YEAR, sequence: IdentifierService.DEFAULT_ISRC_START_SEQUENCE }, // Start at 100 for padding
+                    upc: { sequence: IdentifierService.DEFAULT_UPC_START_SEQUENCE } // 11 digits start
                 };
                 transaction.set(seqDocRef, initialData);
                 return type === 'isrc' ? initialData.isrc.sequence : initialData.upc.sequence;
@@ -38,7 +41,7 @@ export class IdentifierService {
             const data = seqDoc.data();
 
             if (type === 'isrc') {
-                const isrcData = data.isrc || { lastYear: year || 26, sequence: 100 };
+                const isrcData = data.isrc || { lastYear: year || IdentifierService.DEFAULT_ISRC_LAST_YEAR, sequence: IdentifierService.DEFAULT_ISRC_START_SEQUENCE };
                 let currentSeq = isrcData.sequence + 1;
                 let lastYear = isrcData.lastYear;
 
@@ -54,7 +57,7 @@ export class IdentifierService {
                 });
                 return currentSeq;
             } else {
-                const upcData = data.upc || { sequence: 10000000000 };
+                const upcData = data.upc || { sequence: IdentifierService.DEFAULT_UPC_START_SEQUENCE };
                 const currentSeq = upcData.sequence + 1;
                 transaction.update(seqDocRef, { 'upc.sequence': currentSeq });
                 return currentSeq;


### PR DESCRIPTION
🎯 **What:** The magic numbers for generating new identifiers (ISRC last year `26`, ISRC sequence `100`, UPC sequence `10000000000`) within `getNextSequence` in `IdentifierService.ts` were replaced with descriptive class-level constants `DEFAULT_ISRC_LAST_YEAR`, `DEFAULT_ISRC_START_SEQUENCE`, and `DEFAULT_UPC_START_SEQUENCE`.
💡 **Why:** By extracting these hardcoded values into static readonly constants at the top of the file, we improve codebase maintainability. It prevents typos and makes it easier for other developers to identify, adjust, and understand the default configuration for identifier sequences.
✅ **Verification:** Ran `npm run typecheck` which passed without errors. Ran the full unit test suite `npm test -- --run` to ensure no functionality is broken.
✨ **Result:** A cleaner `IdentifierService.ts` code structure without changing behavior.

---
*PR created automatically by Jules for task [7028381694044109900](https://jules.google.com/task/7028381694044109900) started by @the-walking-agency-det*