### PR TITLE
🔒 fix(distribution): remove password and key command-line arguments

### DIFF
--- a/execution/distribution/aspera_uploader.py
+++ b/execution/distribution/aspera_uploader.py
@@ -144,8 +144,6 @@ if __name__ == "__main__":
     parser.add_argument("--host", required=True, help="Aspera Host")
     parser.add_argument("--port", type=int, default=33001, help="Aspera Port")
     parser.add_argument("--user", required=True, help="Aspera Username")
-    parser.add_argument("--password", help="Aspera Password")
-    parser.add_argument("--key", help="Path to Private Key file")
     parser.add_argument("--local", required=True, help="Local file or directory to upload")
     parser.add_argument("--remote", default=".", help="Remote directory path")
     parser.add_argument("--rate", default="100M", help="Target transfer rate (e.g., 100M)")
@@ -153,12 +151,9 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    # Security: Prioritize Environment Variables
-    password = os.environ.get("ASPERA_PASSWORD", args.password)
-    key_path = os.environ.get("ASPERA_KEY_PATH", args.key)
-    # Prioritize environment variables for secrets if arguments are not provided
-    password = args.password or os.environ.get("ASPERA_SCP_PASS")
-    key_path = args.key or os.environ.get("ASPERA_KEY")
+    # Security: Strictly require Environment Variables for secrets
+    password = os.environ.get("ASPERA_PASSWORD") or os.environ.get("ASPERA_SCP_PASS")
+    key_path = os.environ.get("ASPERA_KEY_PATH") or os.environ.get("ASPERA_KEY")
 
     uploader = AsperaUploader(storage_path=args.storage_path)
     result = uploader.upload(

--- a/execution/distribution/deliver_apple.py
+++ b/execution/distribution/deliver_apple.py
@@ -297,7 +297,6 @@ if __name__ == "__main__":
 
     # Global options
     parser.add_argument("--apple-id", help="Apple ID (overrides env var)")
-    parser.add_argument("--password", help="App-specific password (overrides env var)")
     parser.add_argument("--provider-id", help="Provider short name (overrides env var)")
 
     args = parser.parse_args()
@@ -308,7 +307,6 @@ if __name__ == "__main__":
 
     transporter = AppleTransporter(
         apple_id=args.apple_id,
-        password=args.password,
         provider_id=args.provider_id
     )
 

--- a/execution/distribution/sftp_uploader.py
+++ b/execution/distribution/sftp_uploader.py
@@ -128,8 +128,6 @@ def setup_args():
     parser.add_argument("--host", required=True, help="SFTP Host")
     parser.add_argument("--port", type=int, default=22, help="SFTP Port")
     parser.add_argument("--user", required=True, help="SFTP Username")
-    parser.add_argument("--password", help="SFTP Password")
-    parser.add_argument("--key", help="Path to Private Key file")
     parser.add_argument("--local", required=True, help="Local file or directory to upload")
     parser.add_argument("--remote", default=".", help="Remote directory path")
     parser.add_argument("--storage-path", help="Path for logs and session data")
@@ -138,12 +136,9 @@ def setup_args():
 if __name__ == "__main__":
     args = setup_args()
 
-    # Security: Prioritize Environment Variables
-    password = os.environ.get("SFTP_PASSWORD", args.password)
-    key_path = os.environ.get("SFTP_KEY_PATH", args.key)
-    # Prioritize environment variables for secrets if arguments are not provided
-    password = args.password or os.environ.get("SFTP_PASSWORD")
-    key_path = args.key or os.environ.get("SFTP_KEY")
+    # Security: Strictly require Environment Variables for secrets
+    password = os.environ.get("SFTP_PASSWORD")
+    key_path = os.environ.get("SFTP_KEY_PATH") or os.environ.get("SFTP_KEY")
 
     uploader = SFTPUploader(storage_path=args.storage_path)
     result = uploader.upload(


### PR DESCRIPTION
🎯 **What:** Removed the `--password` and `--key` command-line arguments from `aspera_uploader.py`, `sftp_uploader.py`, and `deliver_apple.py`. Updated the logic to securely fetch these secrets exclusively via environment variables.

⚠️ **Risk:** Passing sensitive credentials like passwords and private keys as command-line arguments exposed them to system process monitoring tools (e.g., `ps`), leading to a critical security vulnerability and potential unauthorized access.

🛡️ **Solution:** Dropped the insecure argument parsing for secrets. Enforced the use of environment variables (`ASPERA_PASSWORD`, `SFTP_PASSWORD`, etc.) as the strict source of truth for authenticating distribution engine payloads.

---
*PR created automatically by Jules for task [6336812121529413338](https://jules.google.com/task/6336812121529413338) started by @the-walking-agency-det*