### PR TITLE
chore: enable AppCheck for production in sendEmail cloud function

### DIFF
--- a/packages/firebase/src/email/sendEmail.ts
+++ b/packages/firebase/src/email/sendEmail.ts
@@ -243,7 +243,7 @@ export const sendEmail = onCall(
     {
         secrets: [resendApiKey],
         region: 'us-central1',
-        enforceAppCheck: false, // TODO: Enable for production
+        enforceAppCheck: true,
         maxInstances: 10,
     },
     async (request): Promise<SendEmailResponse> => {


### PR DESCRIPTION
Enabled AppCheck enforcement for the `sendEmail` cloud function by changing `enforceAppCheck: false` to `enforceAppCheck: true` and removing the TODO comment.

---
*PR created automatically by Jules for task [3338668033656289592](https://jules.google.com/task/3338668033656289592) started by @the-walking-agency-det*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced email service security by enforcing stricter request verification to ensure only authorized requests are processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->