### PR TITLE
🧪 Add missing error path test for generateSecureHex

### DIFF
--- a/packages/renderer/src/utils/security.test.ts
+++ b/packages/renderer/src/utils/security.test.ts
@@ -20,6 +20,20 @@ describe('Security Utilities', () => {
       expect(hex).toMatch(/^[0-9a-f]+$/);
     });
 
+
+    it('should throw an error if crypto.getRandomValues is not a function', () => {
+      const originalCrypto = globalThis.crypto;
+      try {
+        Object.defineProperty(globalThis, 'crypto', { value: { getRandomValues: 'not a function' }, configurable: true });
+        expect(() => generateSecureHex(10)).toThrow(
+          '[Security] crypto.getRandomValues is required but not available. Cannot generate secure random values.'
+        );
+      } finally {
+        Object.defineProperty(globalThis, 'crypto', { value: originalCrypto, configurable: true });
+      }
+    });
+
+
     it('should throw an error if crypto.getRandomValues is not available', () => {
       const originalCrypto = globalThis.crypto;
       try {

--- a/packages/renderer/src/utils/security.ts
+++ b/packages/renderer/src/utils/security.ts
@@ -29,7 +29,7 @@ export function generateSecureHex(length: number): string {
     // Support both browser (window.crypto) and Node.js (global.crypto or require('crypto').webcrypto)
     const crypto = globalThis.crypto;
 
-    if (!crypto || !crypto.getRandomValues) {
+    if (!crypto || typeof crypto.getRandomValues !== 'function') {
         throw new Error('[Security] crypto.getRandomValues is required but not available. Cannot generate secure random values.');
     }
 


### PR DESCRIPTION
The missing error path for `generateSecureHex` in `packages/renderer/src/utils/security.ts` was addressed. The truthiness check for `crypto.getRandomValues` was improved to use `typeof crypto.getRandomValues !== 'function'`. An accompanying test was added in `packages/renderer/src/utils/security.test.ts` mocking `globalThis.crypto.getRandomValues` to something that isn't a function to verify that the expected error is thrown.

---
*PR created automatically by Jules for task [5358713574766452525](https://jules.google.com/task/5358713574766452525) started by @the-walking-agency-det*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened validation of cryptographic random value generation with stricter type checking.

* **Tests**
  * Added test coverage for edge cases in security validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->