### PR TITLE
fix(renderer): add boot watchdog fallback for startup spinner

### DIFF
--- a/packages/renderer/index.html
+++ b/packages/renderer/index.html
@@ -99,6 +99,54 @@
         to { transform: translate(-50%, -50%) rotate(360deg); }
       }
     </style>
+
+    <script>
+      // Startup watchdog: avoid infinite spinner when module boot fails before React mounts.
+      (function () {
+        const BOOT_TIMEOUT_MS = 12000;
+
+        function showStartupFallback(reason) {
+          const root = document.getElementById('root');
+          if (!root || root.childElementCount > 0) return;
+
+          const webglAvailable = (() => {
+            try {
+              const canvas = document.createElement('canvas');
+              return !!(window.WebGLRenderingContext && (canvas.getContext('webgl') || canvas.getContext('experimental-webgl')));
+            } catch {
+              return false;
+            }
+          })();
+
+          root.innerHTML = `
+            <div style="display:flex;align-items:center;justify-content:center;min-height:100vh;background:#0a0a0f;color:#e4e4e7;font-family:system-ui,sans-serif;padding:2rem;text-align:center">
+              <div style="max-width:480px">
+                <h1 style="font-size:1.5rem;margin-bottom:1rem;color:#a78bfa">indiiOS</h1>
+                <p style="margin-bottom:1rem;opacity:0.85">The app took too long to start.</p>
+                <p style="margin-bottom:1.5rem;opacity:0.65;font-size:0.9rem">${reason || 'Startup error detected.'} ${webglAvailable ? '' : 'WebGL appears unavailable in this browser/device.'}</p>
+                <button onclick="location.reload()" style="background:#7c3aed;color:white;border:none;padding:0.75rem 2rem;border-radius:0.5rem;font-size:1rem;cursor:pointer">Reload App</button>
+              </div>
+            </div>`;
+        }
+
+        window.addEventListener('error', (event) => {
+          showStartupFallback(event?.message || 'Script error');
+        });
+
+        window.addEventListener('unhandledrejection', (event) => {
+          const reason = event?.reason instanceof Error ? event.reason.message : 'Unhandled startup promise rejection';
+          showStartupFallback(reason);
+        });
+
+        setTimeout(() => {
+          const root = document.getElementById('root');
+          if (root && root.childElementCount === 0) {
+            showStartupFallback('Startup timeout exceeded (12s).');
+          }
+        }, BOOT_TIMEOUT_MS);
+      })();
+    </script>
+
   </head>
   <body>
     <div id="root"></div>

--- a/packages/renderer/src/main.tsx
+++ b/packages/renderer/src/main.tsx
@@ -27,7 +27,11 @@ import { initSentry } from '@/services/observability/SentryService';
 
 // Initialize Sentry before the app renders. 
 // Item 303: Consent is checked internally within initSentry.
-initSentry();
+try {
+    initSentry();
+} catch (error: unknown) {
+    logger.warn('[Startup] Sentry initialization failed (non-blocking):', error);
+}
 
 
 logger.debug("Indii OS Studio v1.2.6-manual-redeploy");


### PR DESCRIPTION
### Motivation
- Prevent the renderer from showing an infinite CSS spinner when the app fails to boot before React mounts (e.g. errors from 3D/WebGL code on the landing/marketing page or early module/runtime failures).
- Surface an actionable fallback UI and a short diagnostic message so users can reload or identify likely WebGL-related issues instead of being stuck on a blank spinner.

### Description
- Inserted a startup watchdog script into `packages/renderer/index.html` that runs before the module boot and protects `#root` from remaining empty.
- Added global `error` and `unhandledrejection` handlers that render a small fallback UI with a reload button and the error reason when early failures occur.
- Added a 12-second boot timeout that shows the fallback UI if nothing mounts, and a lightweight WebGL availability check included in the diagnostic message.
- The change is defensive and does not alter normal boot behavior when the app loads successfully.

### Testing
- Ran `npm run -s typecheck:renderer`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f356faa878832dbae975047cb94036)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * App now displays a fallback error screen when startup fails instead of showing an infinite loading spinner. WebGL availability information is included when applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->