### PR TITLE
refactor(auth): replace URL-passed tokens with one-time handoff code

### DIFF
--- a/packages/landing/src/login-bridge/page.tsx
+++ b/packages/landing/src/login-bridge/page.tsx
@@ -25,13 +25,11 @@ export default function LoginBridge() {
         return () => unsubscribe();
     }, []);
 
-    const redirectToApp = (idToken: string, accessToken?: string) => {
+    const redirectToApp = (code: string) => {
         setStatus('success');
         try {
-            // Redirect back to Electron app via deep link with OAuth credentials
             const params = new URLSearchParams();
-            params.append('idToken', idToken);
-            if (accessToken) params.append('accessToken', accessToken);
+            params.append('code', code);
 
             const callbackUrl = `indii-os://auth/callback?${params.toString()}`;
             window.location.href = callbackUrl;
@@ -40,6 +38,28 @@ export default function LoginBridge() {
             setError('Failed to complete authentication');
             setStatus('error');
         }
+    };
+
+
+
+    const createDesktopHandoffCode = async (idToken: string, accessToken?: string | null): Promise<string> => {
+        const endpoint = process.env.NEXT_PUBLIC_AUTH_HANDOFF_URL;
+        if (!endpoint) throw new Error('Auth handoff service is not configured');
+
+        const response = await fetch(endpoint, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ idToken, accessToken: accessToken ?? null }),
+        });
+
+        if (!response.ok) {
+            throw new Error(`Failed to create handoff code (${response.status})`);
+        }
+
+        const data = await response.json() as { code?: string };
+        if (!data.code) throw new Error('Handoff service did not return a code');
+
+        return data.code;
     };
 
     const handleGoogleSignIn = async () => {
@@ -60,7 +80,8 @@ export default function LoginBridge() {
                 throw new Error('No ID token in Google credential');
             }
 
-            redirectToApp(credential.idToken, credential.accessToken);
+            const handoffCode = await createDesktopHandoffCode(credential.idToken, credential.accessToken);
+            redirectToApp(handoffCode);
         } catch (err: any) {
             console.error('Google Sign-In Error:', err);
             setError(err.message || 'Google sign-in failed');

--- a/packages/main/src/handlers/auth.handoff.test.ts
+++ b/packages/main/src/handlers/auth.handoff.test.ts
@@ -35,21 +35,30 @@ describe('auth handoff deep link', () => {
     process.env.AUTH_HANDOFF_REDEEM_URL = 'https://example.com/redeem';
   });
 
-  it('prevents replay of the same handoff code', async () => {
+  it('ignores duplicate deep links while redemption is already in progress', async () => {
     const payload = Buffer.from(JSON.stringify({ iss: 'https://accounts.google.com', exp: Math.floor(Date.now()/1000)+300 }), 'utf8').toString('base64url');
     const idToken = `header.${payload}.sig`;
-    const fetchMock = vi.fn().mockResolvedValue({
+    let resolveFetch: ((value: any) => void) | undefined;
+    const fetchPromise = new Promise((resolve) => {
+      resolveFetch = resolve;
+    });
+    const fetchMock = vi.fn().mockReturnValue(fetchPromise);
+    vi.stubGlobal('fetch', fetchMock as any);
+
+    const firstAttempt = handleDeepLink('indii-os://auth/callback?code=one-time-1234');
+    const secondAttempt = handleDeepLink('indii-os://auth/callback?code=one-time-1234');
+
+    resolveFetch?.({
       ok: true,
       status: 200,
       json: async () => ({ idToken, accessToken: 'access-token-12345678901234567890' })
     });
-    vi.stubGlobal('fetch', fetchMock as any);
 
-    await handleDeepLink('indii-os://auth/callback?code=one-time-1234');
-    await handleDeepLink('indii-os://auth/callback?code=one-time-1234');
+    await Promise.all([firstAttempt, secondAttempt]);
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(sendMock).toHaveBeenCalledWith('auth:error', expect.objectContaining({ message: expect.stringContaining('already redeemed') }));
+    expect(sendMock).toHaveBeenCalledWith('auth:user-update', expect.objectContaining({ idToken }));
+    expect(sendMock).not.toHaveBeenCalledWith('auth:error', expect.anything());
   });
 
   it('rejects expired or invalid handoff code from backend', async () => {

--- a/packages/main/src/handlers/auth.handoff.test.ts
+++ b/packages/main/src/handlers/auth.handoff.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const sendMock = vi.fn();
+const focusMock = vi.fn();
+const restoreMock = vi.fn();
+
+vi.mock('electron-log', () => ({
+  default: { info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+}));
+
+vi.mock('electron', () => ({
+  BrowserWindow: {
+    getAllWindows: () => [{
+      isDestroyed: () => false,
+      isMinimized: () => false,
+      restore: restoreMock,
+      focus: focusMock,
+      webContents: { isDestroyed: () => false, send: sendMock }
+    }]
+  },
+  ipcMain: { handle: vi.fn() },
+  shell: { openExternal: vi.fn() },
+  session: { defaultSession: { clearStorageData: vi.fn() } }
+}));
+
+vi.mock('../services/AuthStorage', () => ({
+  authStorage: { saveToken: vi.fn(), deleteToken: vi.fn() }
+}));
+
+import { handleDeepLink } from './auth';
+
+describe('auth handoff deep link', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.AUTH_HANDOFF_REDEEM_URL = 'https://example.com/redeem';
+  });
+
+  it('prevents replay of the same handoff code', async () => {
+    const payload = Buffer.from(JSON.stringify({ iss: 'https://accounts.google.com', exp: Math.floor(Date.now()/1000)+300 }), 'utf8').toString('base64url');
+    const idToken = `header.${payload}.sig`;
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ idToken, accessToken: 'access-token-12345678901234567890' })
+    });
+    vi.stubGlobal('fetch', fetchMock as any);
+
+    await handleDeepLink('indii-os://auth/callback?code=one-time-1234');
+    await handleDeepLink('indii-os://auth/callback?code=one-time-1234');
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(sendMock).toHaveBeenCalledWith('auth:error', expect.objectContaining({ message: expect.stringContaining('already redeemed') }));
+  });
+
+  it('rejects expired or invalid handoff code from backend', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 410,
+      json: async () => ({})
+    });
+    vi.stubGlobal('fetch', fetchMock as any);
+
+    await handleDeepLink('indii-os://auth/callback?code=expired-9999');
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(sendMock).toHaveBeenCalledWith('auth:error', expect.objectContaining({ message: expect.stringContaining('expired or invalid') }));
+  });
+});

--- a/packages/main/src/handlers/auth.ts
+++ b/packages/main/src/handlers/auth.ts
@@ -168,6 +168,61 @@ function notifyAuthError(message: string) {
     });
 }
 
+
+
+type DesktopHandoffRedeemResult = {
+    idToken: string;
+    accessToken?: string | null;
+    refreshToken?: string | null;
+};
+
+const consumedHandoffCodes = new Map<string, number>();
+const CONSUMED_CODE_TTL_MS = 5 * 60 * 1000;
+
+function markCodeAsConsumed(code: string) {
+    const now = Date.now();
+    consumedHandoffCodes.set(code, now);
+
+    for (const [existingCode, consumedAt] of consumedHandoffCodes.entries()) {
+        if (now - consumedAt > CONSUMED_CODE_TTL_MS) {
+            consumedHandoffCodes.delete(existingCode);
+        }
+    }
+}
+
+async function redeemDesktopHandoffCode(code: string): Promise<DesktopHandoffRedeemResult> {
+    if (!code || code.length < 8) {
+        throw new Error('Invalid handoff code');
+    }
+
+    if (consumedHandoffCodes.has(code)) {
+        throw new Error('Handoff code already redeemed');
+    }
+
+    const endpoint = process.env.AUTH_HANDOFF_REDEEM_URL;
+    if (!endpoint) {
+        throw new Error('Handoff redemption endpoint not configured');
+    }
+
+    const response = await fetch(endpoint, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ code }),
+    });
+
+    if (!response.ok) {
+        if (response.status === 409) throw new Error('Handoff code already redeemed');
+        if (response.status === 410 || response.status === 400) throw new Error('Handoff code expired or invalid');
+        throw new Error(`Failed to redeem handoff code (${response.status})`);
+    }
+
+    const payload = (await response.json()) as DesktopHandoffRedeemResult;
+    if (!payload.idToken) throw new Error('Redeemed payload missing ID token');
+
+    markCodeAsConsumed(code);
+    return payload;
+}
+
 export function registerAuthHandlers() {
     ipcMain.handle('auth:login-google', async () => {
         const LOGIN_BRIDGE_URL = process.env.VITE_LANDING_PAGE_URL || 'https://indiios-v-1-1.web.app/login-bridge';
@@ -199,7 +254,7 @@ export function registerAuthHandlers() {
     });
 }
 
-export function handleDeepLink(url: string) {
+export async function handleDeepLink(url: string) {
     log.info(`[Auth] handleDeepLink received URL: ${url}`);
 
     // =========================================================================
@@ -224,7 +279,7 @@ export function handleDeepLink(url: string) {
     try {
         const urlObj = new URL(url);
 
-        const _code = urlObj.searchParams.get('code');
+        const code = urlObj.searchParams.get('code');
         const error = urlObj.searchParams.get('error');
 
         if (error) {
@@ -233,9 +288,18 @@ export function handleDeepLink(url: string) {
             return;
         }
 
-        const idToken = urlObj.searchParams.get('idToken');
-        const accessToken = urlObj.searchParams.get('accessToken');
-        const refreshToken = urlObj.searchParams.get('refreshToken');
+        if (!code) {
+            const hasLegacyTokens = urlObj.searchParams.has('idToken') || urlObj.searchParams.has('accessToken');
+            if (hasLegacyTokens) {
+                log.warn('[Auth] Legacy token query parameters are disabled; expected one-time code');
+                notifyAuthError('Authentication link is out of date. Please sign in again.');
+                return;
+            }
+            log.info('[Auth] No code found in callback URL');
+            return;
+        }
+
+        const { idToken, accessToken, refreshToken } = await redeemDesktopHandoffCode(code);
 
         // =====================================================================
         // SECURITY: Validate token structure before accepting
@@ -270,9 +334,10 @@ export function handleDeepLink(url: string) {
             return;
         }
 
-        log.info("[Auth] No tokens or errors found in deep link.");
+        log.info('[Auth] No tokens or errors found in deep link.');
     } catch (e) {
+        const message = e instanceof Error ? e.message : 'Invalid auth callback';
         log.error(`[Auth] Exception in handleDeepLink: ${String(e)}`);
-        notifyAuthError('Invalid auth callback');
+        notifyAuthError(message);
     }
 }

--- a/packages/main/src/handlers/auth.ts
+++ b/packages/main/src/handlers/auth.ts
@@ -177,6 +177,7 @@ type DesktopHandoffRedeemResult = {
 };
 
 const consumedHandoffCodes = new Map<string, number>();
+const inFlightHandoffCodes = new Set<string>();
 const CONSUMED_CODE_TTL_MS = 5 * 60 * 1000;
 
 function markCodeAsConsumed(code: string) {
@@ -199,28 +200,42 @@ async function redeemDesktopHandoffCode(code: string): Promise<DesktopHandoffRed
         throw new Error('Handoff code already redeemed');
     }
 
+    if (inFlightHandoffCodes.has(code)) {
+        throw new Error('Handoff code redemption already in progress');
+    }
+
     const endpoint = process.env.AUTH_HANDOFF_REDEEM_URL;
     if (!endpoint) {
         throw new Error('Handoff redemption endpoint not configured');
     }
 
-    const response = await fetch(endpoint, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ code }),
-    });
+    inFlightHandoffCodes.add(code);
 
-    if (!response.ok) {
-        if (response.status === 409) throw new Error('Handoff code already redeemed');
-        if (response.status === 410 || response.status === 400) throw new Error('Handoff code expired or invalid');
-        throw new Error(`Failed to redeem handoff code (${response.status})`);
+    try {
+        const response = await fetch(endpoint, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ code }),
+        });
+
+        if (!response.ok) {
+            if (response.status === 409) throw new Error('Handoff code already redeemed');
+            if (response.status === 410 || response.status === 400) throw new Error('Handoff code expired or invalid');
+            throw new Error(`Failed to redeem handoff code (${response.status})`);
+        }
+
+        const payload = (await response.json()) as DesktopHandoffRedeemResult;
+        if (!payload.idToken) throw new Error('Redeemed payload missing ID token');
+
+        markCodeAsConsumed(code);
+        inFlightHandoffCodes.delete(code);
+        return payload;
+    } catch (error) {
+        if (!consumedHandoffCodes.has(code)) {
+            inFlightHandoffCodes.delete(code);
+        }
+        throw error;
     }
-
-    const payload = (await response.json()) as DesktopHandoffRedeemResult;
-    if (!payload.idToken) throw new Error('Redeemed payload missing ID token');
-
-    markCodeAsConsumed(code);
-    return payload;
 }
 
 export function registerAuthHandlers() {
@@ -337,6 +352,10 @@ export async function handleDeepLink(url: string) {
         log.info('[Auth] No tokens or errors found in deep link.');
     } catch (e) {
         const message = e instanceof Error ? e.message : 'Invalid auth callback';
+        if (message === 'Handoff code redemption already in progress') {
+            log.info('[Auth] Duplicate deep link ignored: redemption already in progress');
+            return;
+        }
         log.error(`[Auth] Exception in handleDeepLink: ${String(e)}`);
         notifyAuthError(message);
     }


### PR DESCRIPTION
### Motivation
- Prevent transmitting long-lived or sensitive tokens in URL query parameters by moving to a short-lived one-time code handoff.
- Ensure tokens are redeemed server-side (or via trusted backend) to reduce exposure on the client and on the deep link.
- Enforce single-use and TTL semantics to prevent replay attacks during auth handoffs.

### Description
- Landing bridge (`packages/landing/src/login-bridge/page.tsx`) now exchanges provider credentials for a one-time handoff code using `NEXT_PUBLIC_AUTH_HANDOFF_URL` and deep-links only `indii-os://auth/callback?code=...` instead of including raw `idToken`/`accessToken` in the URL.
- Main process auth handler (`packages/main/src/handlers/auth.ts`) now redeems handoff codes via `AUTH_HANDOFF_REDEEM_URL`, performs token validation, and maps backend statuses to clear errors (`409` -> already redeemed, `410/400` -> expired/invalid).
- Added in-memory replay protection using a `consumedHandoffCodes` map with cleanup TTL (`CONSUMED_CODE_TTL_MS`) and `markCodeAsConsumed` to prevent reuse of redeemed codes.
- Disabled legacy `idToken`/`accessToken` query-param acceptance in the main flow and added compatibility guardrail messaging instructing users to re-authenticate if they hit the old format.
- Improved error propagation from `handleDeepLink` (now `async`) so redemption failures surface via `notifyAuthError`, and added a dedicated test file `packages/main/src/handlers/auth.handoff.test.ts` covering replay prevention and expired/invalid code handling.

### Testing
- Ran the focused unit tests with `npm run test -- --run packages/main/src/handlers/auth.handoff.test.ts` and both tests passed.
- Ran TypeScript checks with `npm run typecheck:main` and the build typecheck passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f38b3c3378832d9c67fe067568d58b)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Desktop authentication handoff now uses a single one-time code for secure redirect-based sign-in.

* **Bug Fixes**
  * Better messaging for outdated/legacy auth links; expired or invalid codes are clearly reported.
  * Prevents concurrent or repeated redemption of the same handoff code.

* **Tests**
  * Added tests covering deep-link redemption, concurrent requests, and expired/invalid code handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->