### PR TITLE
fix(landing): harden login bridge deep-link fallback

### DIFF
--- a/packages/landing/src/login-bridge/page.test.tsx
+++ b/packages/landing/src/login-bridge/page.test.tsx
@@ -1,0 +1,118 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react';
+import LoginBridge from './page';
+
+const { signInWithPopupMock, credentialFromResultMock } = vi.hoisted(() => ({
+    signInWithPopupMock: vi.fn(),
+    credentialFromResultMock: vi.fn(),
+}));
+
+vi.mock('firebase/auth', () => ({
+    getAuth: vi.fn(() => ({})),
+    GoogleAuthProvider: class {
+        static credentialFromResult = credentialFromResultMock;
+        addScope() {}
+    },
+    signInWithPopup: (...args: any[]) => signInWithPopupMock(...args),
+    onAuthStateChanged: (_auth: unknown, cb: () => void) => {
+        cb();
+        return () => {};
+    },
+}));
+
+vi.mock('../lib/firebase', () => ({
+    default: {},
+}));
+
+describe('LoginBridge deep-link flows', () => {
+    let container: HTMLDivElement;
+    let root: ReturnType<typeof createRoot>;
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+        container = document.createElement('div');
+        document.body.appendChild(container);
+        root = createRoot(container);
+        Object.defineProperty(window, 'location', {
+            value: { href: 'http://localhost/' },
+            writable: true,
+        });
+        (navigator as any).clipboard = { writeText: vi.fn().mockResolvedValue(undefined) };
+    });
+
+    afterEach(() => {
+        act(() => root.unmount());
+        container.remove();
+        vi.clearAllMocks();
+        vi.useRealTimers();
+    });
+
+    it('shows success redirect state after auth succeeds', async () => {
+        signInWithPopupMock.mockResolvedValue({ user: {} });
+        credentialFromResultMock.mockReturnValue({ idToken: 'id-token', accessToken: 'access-token' });
+
+        await act(async () => {
+            root.render(<LoginBridge />);
+        });
+
+        const btn = container.querySelector('button');
+        expect(btn?.textContent).toContain('Continue with Google');
+
+        await act(async () => {
+            btn?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        });
+
+        expect(container.textContent).toContain('Success! Redirecting to app...');
+        expect(window.location.href).toContain('indii-os://auth/callback?');
+    });
+
+    it('renders deep-link timeout fallback after redirect does not leave page', async () => {
+        signInWithPopupMock.mockResolvedValue({ user: {} });
+        credentialFromResultMock.mockReturnValue({ idToken: 'id-token' });
+
+        await act(async () => {
+            root.render(<LoginBridge />);
+        });
+
+        await act(async () => {
+            container.querySelector('button')?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        });
+
+        await act(async () => {
+            vi.advanceTimersByTime(3000);
+        });
+
+        expect(container.textContent).toContain('Could not switch to the desktop app automatically');
+        expect(container.textContent).toContain('Open app again');
+        expect(container.textContent).toContain('Copy callback token package');
+    });
+
+    it('retries deep link when user clicks Open app again', async () => {
+        signInWithPopupMock.mockResolvedValue({ user: {} });
+        credentialFromResultMock.mockReturnValue({ idToken: 'id-token' });
+
+        await act(async () => {
+            root.render(<LoginBridge />);
+        });
+
+        await act(async () => {
+            container.querySelector('button')?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        });
+
+        await act(async () => {
+            vi.advanceTimersByTime(3000);
+        });
+
+        const before = window.location.href;
+        const retryButton = Array.from(container.querySelectorAll('button')).find((el) => el.textContent?.includes('Open app again'));
+
+        await act(async () => {
+            retryButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        });
+
+        expect(window.location.href).toContain('indii-os://auth/callback?');
+        expect(window.location.href).toBe(before);
+    });
+});

--- a/packages/landing/src/login-bridge/page.tsx
+++ b/packages/landing/src/login-bridge/page.tsx
@@ -1,12 +1,18 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { getAuth, GoogleAuthProvider, signInWithPopup, onAuthStateChanged } from 'firebase/auth';
 import app from '../lib/firebase';
 
+type Status = 'loading' | 'ready' | 'authenticating' | 'success' | 'deepLinkFallback' | 'error';
+
+const DEEP_LINK_TIMEOUT_MS = 3000;
+
 export default function LoginBridge() {
-    const [status, setStatus] = useState<'loading' | 'ready' | 'authenticating' | 'success' | 'error'>('loading');
+    const [status, setStatus] = useState<Status>('loading');
     const [error, setError] = useState<string | null>(null);
+    const [callbackPackage, setCallbackPackage] = useState<string | null>(null);
+    const timeoutRef = useRef<number | null>(null);
 
     useEffect(() => {
         if (!app) {
@@ -16,28 +22,54 @@ export default function LoginBridge() {
         }
         const auth = getAuth(app);
 
-        // Check if already logged in - but we need to force a fresh sign-in to get OAuth tokens
-        // So we just set status to ready
         const unsubscribe = onAuthStateChanged(auth, () => {
             setStatus('ready');
         });
 
-        return () => unsubscribe();
+        return () => {
+            unsubscribe();
+            if (timeoutRef.current) {
+                window.clearTimeout(timeoutRef.current);
+            }
+        };
     }, []);
 
     const redirectToApp = (idToken: string, accessToken?: string) => {
         setStatus('success');
+        setError(null);
         try {
-            // Redirect back to Electron app via deep link with OAuth credentials
             const params = new URLSearchParams();
             params.append('idToken', idToken);
             if (accessToken) params.append('accessToken', accessToken);
 
             const callbackUrl = `indii-os://auth/callback?${params.toString()}`;
+            setCallbackPackage(callbackUrl);
             window.location.href = callbackUrl;
+
+            timeoutRef.current = window.setTimeout(() => {
+                const timeoutEvent = {
+                    event: 'landing_login_bridge_deep_link_timeout',
+                    callbackUrlScheme: 'indii-os',
+                    timedOutAfterMs: DEEP_LINK_TIMEOUT_MS,
+                };
+                console.warn('Deep link redirect timeout', timeoutEvent);
+                window.dispatchEvent(new CustomEvent('indiios:deep-link-timeout', { detail: timeoutEvent }));
+                setStatus('deepLinkFallback');
+            }, DEEP_LINK_TIMEOUT_MS);
         } catch (err) {
             console.error('Failed to redirect:', err);
             setError('Failed to complete authentication');
+            setStatus('error');
+        }
+    };
+
+    const copyCallbackPackage = async () => {
+        if (!callbackPackage) return;
+        try {
+            await navigator.clipboard.writeText(callbackPackage);
+        } catch (err) {
+            console.error('Failed to copy callback package:', err);
+            setError('Could not copy callback token package. Please retry and keep this page open.');
             setStatus('error');
         }
     };
@@ -63,6 +95,12 @@ export default function LoginBridge() {
             redirectToApp(credential.idToken, credential.accessToken);
         } catch (err: any) {
             console.error('Google Sign-In Error:', err);
+            const code = err?.code || '';
+            if (code === 'auth/popup-closed-by-user' || code === 'auth/popup-blocked') {
+                setError('Sign-in popup was closed or blocked. Allow popups for this site and try again.');
+                setStatus('ready');
+                return;
+            }
             setError(err.message || 'Google sign-in failed');
             setStatus('error');
         }
@@ -83,71 +121,40 @@ export default function LoginBridge() {
                 )}
 
                 {status === 'ready' && (
-                    <button
-                        onClick={handleGoogleSignIn}
-                        className="w-full flex items-center justify-center gap-3 px-6 py-3 bg-white text-black font-semibold rounded-lg hover:bg-gray-100 transition-colors"
-                    >
-                        <svg className="w-5 h-5" viewBox="0 0 24 24">
-                            <path
-                                fill="#4285F4"
-                                d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
-                            />
-                            <path
-                                fill="#34A853"
-                                d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
-                            />
-                            <path
-                                fill="#FBBC05"
-                                d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
-                            />
-                            <path
-                                fill="#EA4335"
-                                d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
-                            />
-                        </svg>
+                    <button onClick={handleGoogleSignIn} className="w-full flex items-center justify-center gap-3 px-6 py-3 bg-white text-black font-semibold rounded-lg hover:bg-gray-100 transition-colors">
+                        <svg className="w-5 h-5" viewBox="0 0 24 24"><path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z" /><path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" /><path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" /><path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" /></svg>
                         Continue with Google
                     </button>
                 )}
 
                 {status === 'authenticating' && (
-                    <div className="py-8">
-                        <div className="flex items-center justify-center mb-4">
-                            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-emerald-500"></div>
-                        </div>
-                        <p className="text-neutral-400">Signing in...</p>
-                    </div>
+                    <div className="py-8"><div className="flex items-center justify-center mb-4"><div className="animate-spin rounded-full h-8 w-8 border-b-2 border-emerald-500"></div></div><p className="text-neutral-400">Signing in...</p></div>
                 )}
 
                 {status === 'success' && (
-                    <div className="py-8">
-                        <div className="flex items-center justify-center mb-4">
-                            <svg className="w-12 h-12 text-emerald-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-                            </svg>
+                    <div className="py-8"><div className="flex items-center justify-center mb-4"><svg className="w-12 h-12 text-emerald-500" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" /></svg></div><p className="text-emerald-400 font-medium">Success! Redirecting to app...</p></div>
+                )}
+
+                {status === 'deepLinkFallback' && (
+                    <div className="py-4 text-left">
+                        <div className="bg-amber-500/10 border border-amber-500/50 text-amber-200 p-4 rounded-lg mb-4">
+                            Could not switch to the desktop app automatically. The app may not be running, or the indii-os:// protocol may not be registered.
                         </div>
-                        <p className="text-emerald-400 font-medium">Success! Redirecting to app...</p>
+                        <div className="flex gap-2">
+                            <button onClick={() => callbackPackage && (window.location.href = callbackPackage)} className="px-4 py-2 bg-white text-black rounded-lg hover:bg-gray-100 transition-colors">Open app again</button>
+                            <button onClick={copyCallbackPackage} className="px-4 py-2 bg-neutral-800 text-white rounded-lg hover:bg-neutral-700 transition-colors">Copy callback token package</button>
+                        </div>
                     </div>
                 )}
 
                 {status === 'error' && (
                     <div className="py-4">
-                        <div className="bg-red-500/10 border border-red-500/50 text-red-400 p-4 rounded-lg mb-4">
-                            {error || 'An error occurred'}
-                        </div>
-                        <button
-                            onClick={() => setStatus('ready')}
-                            className="px-6 py-2 bg-neutral-800 text-white rounded-lg hover:bg-neutral-700 transition-colors"
-                        >
-                            Try Again
-                        </button>
+                        <div className="bg-red-500/10 border border-red-500/50 text-red-400 p-4 rounded-lg mb-4">{error || 'An error occurred'}</div>
+                        <button onClick={() => setStatus('ready')} className="px-6 py-2 bg-neutral-800 text-white rounded-lg hover:bg-neutral-700 transition-colors">Try Again</button>
                     </div>
                 )}
 
-                <div className="mt-6 pt-6 border-t border-neutral-800">
-                    <p className="text-neutral-500 text-xs">
-                        This page authenticates you with Google and redirects back to the indiiOS desktop app.
-                    </p>
-                </div>
+                <div className="mt-6 pt-6 border-t border-neutral-800"><p className="text-neutral-500 text-xs">This page authenticates you with Google and redirects back to the indiiOS desktop app.</p></div>
             </div>
         </div>
     );


### PR DESCRIPTION
### Motivation
- Prevent users from being left on an indefinite spinner after auth when the desktop app/protocol does not open. 
- Provide a clear, recoverable UI and telemetry so systemic protocol/deep-link failures can be detected and mitigated. 
- Handle popup-closed/blocked Google auth flows so the page returns to a usable state instead of `authenticating` indefinitely. 

### Description
- Add a short deep-link timeout (`DEEP_LINK_TIMEOUT_MS = 3000`) in `redirectToApp` that transitions UI from `success` to a recoverable `deepLinkFallback` state if the page remains visible after setting `window.location.href`. 
- Persist the generated callback deep-link string in state (`callbackPackage`) and expose a `copyCallbackPackage` action to copy it to the clipboard for manual handoff. 
- Add fallback UI showing an explanatory message plus buttons for `Open app again` (retry deep link) and `Copy callback token package`. 
- Emit deep-link timeout telemetry via `console.warn` and a browser `CustomEvent` named `indiios:deep-link-timeout`, and add guarded popup error handling in `handleGoogleSignIn` to return to `ready` for `auth/popup-closed-by-user` and `auth/popup-blocked` cases. 
- Add component tests at `packages/landing/src/login-bridge/page.test.tsx` covering success redirect, deep-link timeout fallback rendering, and retry behavior. 

### Testing
- Ran the new component tests with `npm run test -- packages/landing/src/login-bridge/page.test.tsx --run`, and all tests passed (`3 tests` passed). 
- The test run exercised the deep-link timeout path and retry behavior and completed successfully under `vitest`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f38b365144832d9962d87defa250df)