### PR TITLE
feat(main): make Google desktop auth native-first with bridge fallback

### DIFF
--- a/packages/main/src/handlers/auth.login-google.test.ts
+++ b/packages/main/src/handlers/auth.login-google.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const handleMock = vi.fn();
+const openExternalMock = vi.fn();
+const sendMock = vi.fn();
+const getAllWindowsMock = vi.fn(() => [
+  {
+    isDestroyed: () => false,
+    webContents: {
+      isDestroyed: () => false,
+      send: sendMock,
+    },
+  },
+]);
+
+vi.mock('electron', () => ({
+  ipcMain: { handle: handleMock },
+  shell: { openExternal: openExternalMock },
+  BrowserWindow: { getAllWindows: getAllWindowsMock },
+  session: {
+    defaultSession: {
+      clearStorageData: vi.fn(),
+    },
+  },
+}));
+
+vi.mock('electron-log', () => ({
+  default: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock('../services/AuthStorage', () => ({
+  authStorage: {
+    deleteToken: vi.fn(),
+    saveToken: vi.fn(),
+  },
+}));
+
+describe('auth:login-google handler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.INDIIOS_ENABLE_LOGIN_BRIDGE;
+    delete process.env.VITE_LANDING_PAGE_URL;
+  });
+
+  it('uses native desktop path by default', async () => {
+    const { registerAuthHandlers } = await import('./auth');
+    registerAuthHandlers();
+
+    const loginHandler = handleMock.mock.calls.find(([channel]) => channel === 'auth:login-google')?.[1];
+    expect(loginHandler).toBeDefined();
+
+    const result = await loginHandler();
+
+    expect(result).toEqual({ mode: 'native' });
+    expect(sendMock).toHaveBeenCalledWith('auth:begin-native-google');
+    expect(openExternalMock).not.toHaveBeenCalled();
+  });
+
+  it('uses web bridge fallback when enabled', async () => {
+    process.env.INDIIOS_ENABLE_LOGIN_BRIDGE = 'true';
+    process.env.VITE_LANDING_PAGE_URL = 'https://example.com/login-bridge';
+
+    const { registerAuthHandlers } = await import('./auth');
+    registerAuthHandlers();
+
+    const loginHandler = handleMock.mock.calls.find(([channel]) => channel === 'auth:login-google')?.[1];
+    const result = await loginHandler();
+
+    expect(result).toEqual({ mode: 'bridge' });
+    expect(openExternalMock).toHaveBeenCalledWith('https://example.com/login-bridge');
+    expect(sendMock).toHaveBeenCalledWith('auth:bridge-warning', expect.any(Object));
+  });
+
+  it('returns error when fallback enabled but bridge env var missing', async () => {
+    process.env.INDIIOS_ENABLE_LOGIN_BRIDGE = 'true';
+
+    const { registerAuthHandlers } = await import('./auth');
+    registerAuthHandlers();
+
+    const loginHandler = handleMock.mock.calls.find(([channel]) => channel === 'auth:login-google')?.[1];
+    const result = await loginHandler();
+
+    expect(result).toEqual({
+      mode: 'error',
+      message: 'Web login bridge fallback is enabled but VITE_LANDING_PAGE_URL is missing.',
+    });
+    expect(openExternalMock).not.toHaveBeenCalled();
+    expect(sendMock).toHaveBeenCalledWith('auth:error', {
+      message: 'Web login bridge fallback is enabled but VITE_LANDING_PAGE_URL is missing.',
+    });
+  });
+});

--- a/packages/main/src/handlers/auth.ts
+++ b/packages/main/src/handlers/auth.ts
@@ -168,11 +168,73 @@ function notifyAuthError(message: string) {
     });
 }
 
+function notifyBridgeWarning(message: string) {
+    const wins = BrowserWindow.getAllWindows();
+    log.warn(`[Auth] Notifying ${wins.length} window(s) of bridge fallback: ${message}`);
+    wins.forEach(w => {
+        if (!w.isDestroyed() && !w.webContents.isDestroyed()) {
+            try {
+                w.webContents.send('auth:bridge-warning', { message });
+            } catch (err) {
+                log.warn(`[Auth] Failed to send auth bridge warning: ${err}`);
+            }
+        }
+    });
+}
+
 export function registerAuthHandlers() {
     ipcMain.handle('auth:login-google', async () => {
-        const LOGIN_BRIDGE_URL = process.env.VITE_LANDING_PAGE_URL || 'https://indiios-v-1-1.web.app/login-bridge';
-        log.info("[Auth] Redirecting to Login Bridge:", LOGIN_BRIDGE_URL);
-        await shell.openExternal(LOGIN_BRIDGE_URL);
+        const enableBridgeFallback = process.env.INDIIOS_ENABLE_LOGIN_BRIDGE === 'true';
+        const LOGIN_BRIDGE_URL = process.env.VITE_LANDING_PAGE_URL;
+
+        if (enableBridgeFallback && LOGIN_BRIDGE_URL) {
+            const bridgeWarning = 'Google login is using the web login bridge fallback.';
+            log.warn(`[Auth] ${bridgeWarning} URL: ${LOGIN_BRIDGE_URL}`);
+            notifyBridgeWarning(bridgeWarning);
+            await shell.openExternal(LOGIN_BRIDGE_URL);
+            return { mode: 'bridge' };
+        }
+
+        if (enableBridgeFallback && !LOGIN_BRIDGE_URL) {
+            const errorMessage = 'Web login bridge fallback is enabled but VITE_LANDING_PAGE_URL is missing.';
+            log.error(`[Auth] ${errorMessage}`);
+            notifyAuthError(errorMessage);
+            return { mode: 'error', message: errorMessage };
+        }
+
+        log.info('[Auth] Starting native desktop Google OAuth flow.');
+        const wins = BrowserWindow.getAllWindows();
+        wins.forEach(w => {
+            if (!w.isDestroyed() && !w.webContents.isDestroyed()) {
+                try {
+                    w.webContents.send('auth:begin-native-google');
+                } catch (err) {
+                    log.warn(`[Auth] Failed to signal native Google auth start: ${err}`);
+                }
+            }
+        });
+
+        return { mode: 'native' };
+    });
+
+    ipcMain.handle('auth:complete-native-google', async (_event, payload: { idToken?: string; accessToken?: string | null; error?: string }) => {
+        if (payload?.error) {
+            notifyAuthError(payload.error);
+            return;
+        }
+
+        if (!payload?.idToken) {
+            notifyAuthError('Native Google login did not provide an ID token.');
+            return;
+        }
+
+        const tokenValidation = validateTokenStructure(payload.idToken);
+        if (!tokenValidation.valid) {
+            notifyAuthError('Invalid authentication token received');
+            return;
+        }
+
+        notifyAuthSuccess({ idToken: payload.idToken, accessToken: payload.accessToken });
     });
 
     ipcMain.handle('auth:logout', async () => {


### PR DESCRIPTION
### Motivation
- Stop routing production desktop users through the landing/web app by default and prefer a native desktop OAuth flow while keeping the web bridge as an explicit fallback.
- Make bridge usage visible to operators with logs and UI signals and ensure both flows converge to the same success/error notifications.

### Description
- Changed `auth:login-google` to start a native desktop flow by default and return explicit mode metadata (`{ mode: 'native' }`, `{ mode: 'bridge' }`, or `{ mode: 'error', message }`).
- Added `INDIIOS_ENABLE_LOGIN_BRIDGE` + `VITE_LANDING_PAGE_URL` gating so the landing-page bridge is only used when the feature flag is enabled and a URL is provided.
- Added `notifyBridgeWarning` and emit `auth:bridge-warning` when the web bridge fallback is used, and emit clear `auth:error` when fallback is enabled but misconfigured.
- Added `auth:complete-native-google` IPC handler to accept native flow results and validate tokens so native and bridge flows converge via `auth:user-update` and `auth:error` notifications.
- Added unit tests `packages/main/src/handlers/auth.login-google.test.ts` covering native-default, bridge-enabled, and bridge-enabled-without-url cases.

### Testing
- Ran `npm run test -- --run packages/main/src/handlers/auth.login-google.test.ts`, which executed 3 tests and all passed.
- The new tests verify return modes and that appropriate IPC events (`auth:begin-native-google`, `auth:bridge-warning`, `auth:error`) are emitted as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f38b2a59c8832d991012a92311f5f0)