### PR TITLE
Desktop OAuth handoff: implement one-time code flow and redemption with tests

### DIFF
--- a/packages/landing/src/login-bridge/page.tsx
+++ b/packages/landing/src/login-bridge/page.tsx
@@ -25,13 +25,11 @@ export default function LoginBridge() {
         return () => unsubscribe();
     }, []);
 
-    const redirectToApp = (idToken: string, accessToken?: string) => {
+    const redirectToApp = (code: string) => {
         setStatus('success');
         try {
-            // Redirect back to Electron app via deep link with OAuth credentials
             const params = new URLSearchParams();
-            params.append('idToken', idToken);
-            if (accessToken) params.append('accessToken', accessToken);
+            params.append('code', code);
 
             const callbackUrl = `indii-os://auth/callback?${params.toString()}`;
             window.location.href = callbackUrl;
@@ -40,6 +38,28 @@ export default function LoginBridge() {
             setError('Failed to complete authentication');
             setStatus('error');
         }
+    };
+
+
+
+    const createDesktopHandoffCode = async (idToken: string, accessToken?: string | null): Promise<string> => {
+        const endpoint = process.env.NEXT_PUBLIC_AUTH_HANDOFF_URL;
+        if (!endpoint) throw new Error('Auth handoff service is not configured');
+
+        const response = await fetch(endpoint, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ idToken, accessToken: accessToken ?? null }),
+        });
+
+        if (!response.ok) {
+            throw new Error(`Failed to create handoff code (${response.status})`);
+        }
+
+        const data = await response.json() as { code?: string };
+        if (!data.code) throw new Error('Handoff service did not return a code');
+
+        return data.code;
     };
 
     const handleGoogleSignIn = async () => {
@@ -60,7 +80,8 @@ export default function LoginBridge() {
                 throw new Error('No ID token in Google credential');
             }
 
-            redirectToApp(credential.idToken, credential.accessToken);
+            const handoffCode = await createDesktopHandoffCode(credential.idToken, credential.accessToken);
+            redirectToApp(handoffCode);
         } catch (err: any) {
             console.error('Google Sign-In Error:', err);
             setError(err.message || 'Google sign-in failed');

--- a/packages/main/src/handlers/auth.handoff.test.ts
+++ b/packages/main/src/handlers/auth.handoff.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const sendMock = vi.fn();
+const focusMock = vi.fn();
+const restoreMock = vi.fn();
+
+vi.mock('electron-log', () => ({
+  default: { info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+}));
+
+vi.mock('electron', () => ({
+  BrowserWindow: {
+    getAllWindows: () => [{
+      isDestroyed: () => false,
+      isMinimized: () => false,
+      restore: restoreMock,
+      focus: focusMock,
+      webContents: { isDestroyed: () => false, send: sendMock }
+    }]
+  },
+  ipcMain: { handle: vi.fn() },
+  shell: { openExternal: vi.fn() },
+  session: { defaultSession: { clearStorageData: vi.fn() } }
+}));
+
+vi.mock('../services/AuthStorage', () => ({
+  authStorage: { saveToken: vi.fn(), deleteToken: vi.fn() }
+}));
+
+import { handleDeepLink } from './auth';
+
+describe('auth handoff deep link', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.AUTH_HANDOFF_REDEEM_URL = 'https://example.com/redeem';
+  });
+
+  it('prevents replay of the same handoff code', async () => {
+    const payload = Buffer.from(JSON.stringify({ iss: 'https://accounts.google.com', exp: Math.floor(Date.now()/1000)+300 }), 'utf8').toString('base64url');
+    const idToken = `header.${payload}.sig`;
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ idToken, accessToken: 'access-token-12345678901234567890' })
+    });
+    vi.stubGlobal('fetch', fetchMock as any);
+
+    await handleDeepLink('indii-os://auth/callback?code=one-time-1234');
+    await handleDeepLink('indii-os://auth/callback?code=one-time-1234');
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(sendMock).toHaveBeenCalledWith('auth:error', expect.objectContaining({ message: expect.stringContaining('already redeemed') }));
+  });
+
+  it('rejects expired or invalid handoff code from backend', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 410,
+      json: async () => ({})
+    });
+    vi.stubGlobal('fetch', fetchMock as any);
+
+    await handleDeepLink('indii-os://auth/callback?code=expired-9999');
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(sendMock).toHaveBeenCalledWith('auth:error', expect.objectContaining({ message: expect.stringContaining('expired or invalid') }));
+  });
+
+  it('blocks legacy token callbacks by default during rollout', async () => {
+    delete process.env.AUTH_ALLOW_LEGACY_TOKEN_CALLBACK;
+
+    await handleDeepLink('indii-os://auth/callback?idToken=header.payload.sig&accessToken=legacy-access-token-1234567890');
+
+    expect(sendMock).toHaveBeenCalledWith('auth:error', expect.objectContaining({ message: expect.stringContaining('out of date') }));
+  });
+
+  it('allows legacy token callbacks only when compatibility flag is enabled', async () => {
+    process.env.AUTH_ALLOW_LEGACY_TOKEN_CALLBACK = 'true';
+    const payload = Buffer.from(JSON.stringify({ iss: 'https://accounts.google.com', exp: Math.floor(Date.now()/1000)+300 }), 'utf8').toString('base64url');
+    const idToken = `header.${payload}.sig`;
+
+    await handleDeepLink(`indii-os://auth/callback?idToken=${idToken}&accessToken=legacy-access-token-1234567890`);
+
+    expect(sendMock).toHaveBeenCalledWith('auth:user-update', expect.objectContaining({ idToken }));
+  });
+
+});

--- a/packages/main/src/handlers/auth.ts
+++ b/packages/main/src/handlers/auth.ts
@@ -168,6 +168,66 @@ function notifyAuthError(message: string) {
     });
 }
 
+
+
+
+function isLegacyCallbackEnabled(): boolean {
+    return process.env.AUTH_ALLOW_LEGACY_TOKEN_CALLBACK === 'true';
+}
+
+type DesktopHandoffRedeemResult = {
+    idToken: string;
+    accessToken?: string | null;
+    refreshToken?: string | null;
+};
+
+const consumedHandoffCodes = new Map<string, number>();
+const CONSUMED_CODE_TTL_MS = 5 * 60 * 1000;
+
+function markCodeAsConsumed(code: string) {
+    const now = Date.now();
+    consumedHandoffCodes.set(code, now);
+
+    for (const [existingCode, consumedAt] of consumedHandoffCodes.entries()) {
+        if (now - consumedAt > CONSUMED_CODE_TTL_MS) {
+            consumedHandoffCodes.delete(existingCode);
+        }
+    }
+}
+
+async function redeemDesktopHandoffCode(code: string): Promise<DesktopHandoffRedeemResult> {
+    if (!code || code.length < 8) {
+        throw new Error('Invalid handoff code');
+    }
+
+    if (consumedHandoffCodes.has(code)) {
+        throw new Error('Handoff code already redeemed');
+    }
+
+    const endpoint = process.env.AUTH_HANDOFF_REDEEM_URL;
+    if (!endpoint) {
+        throw new Error('Handoff redemption endpoint not configured');
+    }
+
+    const response = await fetch(endpoint, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ code }),
+    });
+
+    if (!response.ok) {
+        if (response.status === 409) throw new Error('Handoff code already redeemed');
+        if (response.status === 410 || response.status === 400) throw new Error('Handoff code expired or invalid');
+        throw new Error(`Failed to redeem handoff code (${response.status})`);
+    }
+
+    const payload = (await response.json()) as DesktopHandoffRedeemResult;
+    if (!payload.idToken) throw new Error('Redeemed payload missing ID token');
+
+    markCodeAsConsumed(code);
+    return payload;
+}
+
 export function registerAuthHandlers() {
     ipcMain.handle('auth:login-google', async () => {
         const LOGIN_BRIDGE_URL = process.env.VITE_LANDING_PAGE_URL || 'https://indiios-v-1-1.web.app/login-bridge';
@@ -199,7 +259,7 @@ export function registerAuthHandlers() {
     });
 }
 
-export function handleDeepLink(url: string) {
+export async function handleDeepLink(url: string) {
     log.info(`[Auth] handleDeepLink received URL: ${url}`);
 
     // =========================================================================
@@ -224,7 +284,7 @@ export function handleDeepLink(url: string) {
     try {
         const urlObj = new URL(url);
 
-        const _code = urlObj.searchParams.get('code');
+        const code = urlObj.searchParams.get('code');
         const error = urlObj.searchParams.get('error');
 
         if (error) {
@@ -233,9 +293,36 @@ export function handleDeepLink(url: string) {
             return;
         }
 
-        const idToken = urlObj.searchParams.get('idToken');
-        const accessToken = urlObj.searchParams.get('accessToken');
-        const refreshToken = urlObj.searchParams.get('refreshToken');
+        let idToken: string | null = null;
+        let accessToken: string | null = null;
+        let refreshToken: string | null = null;
+
+        if (!code) {
+            const legacyIdToken = urlObj.searchParams.get('idToken');
+            const legacyAccessToken = urlObj.searchParams.get('accessToken');
+            const legacyRefreshToken = urlObj.searchParams.get('refreshToken');
+            const hasLegacyTokens = !!legacyIdToken || !!legacyAccessToken;
+            if (hasLegacyTokens) {
+                if (!isLegacyCallbackEnabled()) {
+                    log.warn('[Auth] Legacy token query parameters are disabled; expected one-time code');
+                    notifyAuthError('Authentication link is out of date. Please sign in again.');
+                    return;
+                }
+
+                log.warn('[Auth] Using temporary legacy token callback compatibility mode');
+                idToken = legacyIdToken;
+                accessToken = legacyAccessToken;
+                refreshToken = legacyRefreshToken;
+            } else {
+                log.info('[Auth] No code found in callback URL');
+                return;
+            }
+        } else {
+            const redeemed = await redeemDesktopHandoffCode(code);
+            idToken = redeemed.idToken;
+            accessToken = redeemed.accessToken ?? null;
+            refreshToken = redeemed.refreshToken ?? null;
+        }
 
         // =====================================================================
         // SECURITY: Validate token structure before accepting
@@ -270,9 +357,10 @@ export function handleDeepLink(url: string) {
             return;
         }
 
-        log.info("[Auth] No tokens or errors found in deep link.");
+        log.info('[Auth] No tokens or errors found in deep link.');
     } catch (e) {
+        const message = e instanceof Error ? e.message : 'Invalid auth callback';
         log.error(`[Auth] Exception in handleDeepLink: ${String(e)}`);
-        notifyAuthError('Invalid auth callback');
+        notifyAuthError(message);
     }
 }


### PR DESCRIPTION
### Motivation

- Replace embedding long-lived tokens in deep links with a one-time handoff code to improve security and prevent token replay.
- Add server-backed handoff creation in the landing page and redemption in the main process so the Electron app receives only validated tokens.
- Prevent repeated redemption of the same handoff code and provide a controlled legacy token fallback behind a feature flag.

### Description

- Updated the landing `login-bridge` to call `createDesktopHandoffCode` which posts Firebase tokens to a handoff service and redirects the app with a one-time `code` instead of raw `idToken`/`accessToken`.
- Added `redeemDesktopHandoffCode`, `markCodeAsConsumed`, and a `consumedHandoffCodes` cache with TTL to the main process auth handler to redeem the code and prevent replays.
- Extended `handleDeepLink` to redeem the one-time code, validate token structure, save refresh tokens, and fall back to legacy token query parameters only when `AUTH_ALLOW_LEGACY_TOKEN_CALLBACK` is enabled.
- Improved logging and error handling in `handleDeepLink` and added `isLegacyCallbackEnabled` helper for the compatibility flag.
- Added unit tests `packages/main/src/handlers/auth.handoff.test.ts` covering replay prevention, expired/invalid code handling, and legacy callback gating.

### Testing

- Ran the unit test suite with Vitest including `auth.handoff.test.ts` (`pnpm -w test`); the new handoff tests executed and passed.
- Existing auth-related test coverage was exercised as part of the run and reported no regressions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f38b3c3378832d9c67fe067568d58b)