### PR TITLE
fix(auth): disable external landing login bridge handoff

### DIFF
--- a/packages/main/src/handlers/auth.ts
+++ b/packages/main/src/handlers/auth.ts
@@ -1,5 +1,5 @@
 import log from 'electron-log';
-import { ipcMain, BrowserWindow, shell, session } from 'electron';
+import { ipcMain, BrowserWindow, session } from 'electron';
 import { authStorage } from '../services/AuthStorage';
 
 // ============================================================================
@@ -170,9 +170,11 @@ function notifyAuthError(message: string) {
 
 export function registerAuthHandlers() {
     ipcMain.handle('auth:login-google', async () => {
-        const LOGIN_BRIDGE_URL = process.env.VITE_LANDING_PAGE_URL || 'https://indiios-v-1-1.web.app/login-bridge';
-        log.info("[Auth] Redirecting to Login Bridge:", LOGIN_BRIDGE_URL);
-        await shell.openExternal(LOGIN_BRIDGE_URL);
+        // NOTE: Explicitly disconnected from the external landing/login bridge.
+        // Auth should occur in-renderer via Firebase signInWithPopup to avoid
+        // cross-app handoff failures and stuck loading states.
+        log.warn('[Auth] auth:login-google IPC called, but external login bridge is disabled. Use renderer Firebase auth flow.');
+        return { ok: false, reason: 'external-login-bridge-disabled' };
     });
 
     ipcMain.handle('auth:logout', async () => {


### PR DESCRIPTION
## Summary
- disconnect the desktop auth IPC from the external landing/login bridge URL
- make `auth:login-google` return a non-success response and log a warning instead of opening `https://indiios-v-1-1.web.app/login-bridge`
- keep logout and deep-link token handling unchanged

## Why
- removes cross-app dependency between marketing/landing surface and desktop app auth flow
- avoids fragile external handoff paths that can contribute to spinner/open-app failures

## Notes
- renderer is already documented to handle Google auth directly via Firebase popup flow (`preload.ts` comment), so this aligns main-process behavior with that architecture.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f38a152c70832da170ba5485428654)