### PR TITLE
auth: add web-login-bridge fallback for Google login and tests

### DIFF
--- a/packages/main/src/handlers/auth.login-google.test.ts
+++ b/packages/main/src/handlers/auth.login-google.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const handleMock = vi.fn();
+const openExternalMock = vi.fn();
+const sendMock = vi.fn();
+const getAllWindowsMock = vi.fn(() => [
+  {
+    isDestroyed: () => false,
+    webContents: {
+      isDestroyed: () => false,
+      send: sendMock,
+    },
+  },
+]);
+
+vi.mock('electron', () => ({
+  ipcMain: { handle: handleMock },
+  shell: { openExternal: openExternalMock },
+  BrowserWindow: { getAllWindows: getAllWindowsMock },
+  session: {
+    defaultSession: {
+      clearStorageData: vi.fn(),
+    },
+  },
+}));
+
+vi.mock('electron-log', () => ({
+  default: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock('../services/AuthStorage', () => ({
+  authStorage: {
+    deleteToken: vi.fn(),
+    saveToken: vi.fn(),
+  },
+}));
+
+describe('auth:login-google handler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.INDIIOS_ENABLE_LOGIN_BRIDGE;
+    delete process.env.LOGIN_BRIDGE_URL;
+  });
+
+  it('uses native desktop path by default', async () => {
+    const { registerAuthHandlers } = await import('./auth');
+    registerAuthHandlers();
+
+    const loginHandler = handleMock.mock.calls.find(([channel]) => channel === 'auth:login-google')?.[1];
+    expect(loginHandler).toBeDefined();
+
+    const result = await loginHandler();
+
+    expect(result).toEqual({ mode: 'native' });
+    expect(sendMock).toHaveBeenCalledWith('auth:begin-native-google');
+    expect(openExternalMock).not.toHaveBeenCalled();
+  });
+
+  it('uses web bridge fallback when enabled', async () => {
+    process.env.INDIIOS_ENABLE_LOGIN_BRIDGE = 'true';
+    process.env.LOGIN_BRIDGE_URL = 'https://example.com/login-bridge';
+
+    const { registerAuthHandlers } = await import('./auth');
+    registerAuthHandlers();
+
+    const loginHandler = handleMock.mock.calls.find(([channel]) => channel === 'auth:login-google')?.[1];
+    const result = await loginHandler();
+
+    expect(result).toEqual({ mode: 'bridge' });
+    expect(openExternalMock).toHaveBeenCalledWith('https://example.com/login-bridge');
+    expect(sendMock).toHaveBeenCalledWith('auth:bridge-warning', expect.any(Object));
+  });
+
+  it('returns error when fallback enabled but bridge env var missing', async () => {
+    process.env.INDIIOS_ENABLE_LOGIN_BRIDGE = 'true';
+
+    const { registerAuthHandlers } = await import('./auth');
+    registerAuthHandlers();
+
+    const loginHandler = handleMock.mock.calls.find(([channel]) => channel === 'auth:login-google')?.[1];
+    const result = await loginHandler();
+
+    expect(result).toEqual({
+      mode: 'error',
+      message: 'Web login bridge fallback is enabled but LOGIN_BRIDGE_URL is missing.',
+    });
+    expect(openExternalMock).not.toHaveBeenCalled();
+    expect(sendMock).toHaveBeenCalledWith('auth:error', {
+      message: 'Web login bridge fallback is enabled but LOGIN_BRIDGE_URL is missing.',
+    });
+  });
+});

--- a/packages/main/src/handlers/auth.ts
+++ b/packages/main/src/handlers/auth.ts
@@ -168,11 +168,73 @@ function notifyAuthError(message: string) {
     });
 }
 
+function notifyBridgeWarning(message: string) {
+    const wins = BrowserWindow.getAllWindows();
+    log.warn(`[Auth] Notifying ${wins.length} window(s) of bridge fallback: ${message}`);
+    wins.forEach(w => {
+        if (!w.isDestroyed() && !w.webContents.isDestroyed()) {
+            try {
+                w.webContents.send('auth:bridge-warning', { message });
+            } catch (err) {
+                log.warn(`[Auth] Failed to send auth bridge warning: ${err}`);
+            }
+        }
+    });
+}
+
 export function registerAuthHandlers() {
     ipcMain.handle('auth:login-google', async () => {
-        const LOGIN_BRIDGE_URL = process.env.VITE_LANDING_PAGE_URL || 'https://indiios-v-1-1.web.app/login-bridge';
-        log.info("[Auth] Redirecting to Login Bridge:", LOGIN_BRIDGE_URL);
-        await shell.openExternal(LOGIN_BRIDGE_URL);
+        const enableBridgeFallback = process.env.INDIIOS_ENABLE_LOGIN_BRIDGE === 'true';
+        const LOGIN_BRIDGE_URL = process.env.LOGIN_BRIDGE_URL;
+
+        if (enableBridgeFallback && LOGIN_BRIDGE_URL) {
+            const bridgeWarning = 'Google login is using the web login bridge fallback.';
+            log.warn(`[Auth] ${bridgeWarning} URL: ${LOGIN_BRIDGE_URL}`);
+            notifyBridgeWarning(bridgeWarning);
+            await shell.openExternal(LOGIN_BRIDGE_URL);
+            return { mode: 'bridge' };
+        }
+
+        if (enableBridgeFallback && !LOGIN_BRIDGE_URL) {
+            const errorMessage = 'Web login bridge fallback is enabled but LOGIN_BRIDGE_URL is missing.';
+            log.error(`[Auth] ${errorMessage}`);
+            notifyAuthError(errorMessage);
+            return { mode: 'error', message: errorMessage };
+        }
+
+        log.info('[Auth] Starting native desktop Google OAuth flow.');
+        const wins = BrowserWindow.getAllWindows();
+        wins.forEach(w => {
+            if (!w.isDestroyed() && !w.webContents.isDestroyed()) {
+                try {
+                    w.webContents.send('auth:begin-native-google');
+                } catch (err) {
+                    log.warn(`[Auth] Failed to signal native Google auth start: ${err}`);
+                }
+            }
+        });
+
+        return { mode: 'native' };
+    });
+
+    ipcMain.handle('auth:complete-native-google', async (_event, payload: { idToken?: string; accessToken?: string | null; error?: string }) => {
+        if (payload?.error) {
+            notifyAuthError(payload.error);
+            return;
+        }
+
+        if (!payload?.idToken) {
+            notifyAuthError('Native Google login did not provide an ID token.');
+            return;
+        }
+
+        const tokenValidation = validateTokenStructure(payload.idToken);
+        if (!tokenValidation.valid) {
+            notifyAuthError('Invalid authentication token received');
+            return;
+        }
+
+        notifyAuthSuccess({ idToken: payload.idToken, accessToken: payload.accessToken });
     });
 
     ipcMain.handle('auth:logout', async () => {


### PR DESCRIPTION
### Motivation

- Provide a configurable fallback to a web "login bridge" for Google sign-in when native desktop flow is not desired or fails, and surface clear warnings/errors to renderer windows.
- Improve coverage by adding unit tests around the Google login handler behaviour.

### Description

- Add fallback logic in `registerAuthHandlers` to check `INDIIOS_ENABLE_LOGIN_BRIDGE` and `LOGIN_BRIDGE_URL` and choose between `bridge`, `error`, and `native` modes.
- Introduce `notifyBridgeWarning` to broadcast `auth:bridge-warning` to renderer windows and emit logs when the bridge fallback is used.
- Update the native flow to signal windows with `auth:begin-native-google` and return `{ mode: 'native' }` when using the desktop OAuth flow.
- Add handling for `auth:complete-native-google` to validate the payload and call `notifyAuthSuccess` or `notifyAuthError` accordingly.
- Add unit tests in `auth.login-google.test.ts` that mock `electron` and verify the three scenarios: default native flow, bridge fallback with URL, and bridge-enabled missing URL error.

### Testing

- Ran the unit tests with `vitest` which execute the new `auth.login-google.test.ts` cases; all tests for the Google login handler passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f38b2a59c8832d991012a92311f5f0)