### PR TITLE
[PR #1641 follow-up] fix(auth): remove stale login-bridge code that broke main typecheck

### DIFF
--- a/packages/main/src/handlers/auth.ts
+++ b/packages/main/src/handlers/auth.ts
@@ -168,20 +168,6 @@ function notifyAuthError(message: string) {
     });
 }
 
-function notifyBridgeWarning(message: string) {
-    const wins = BrowserWindow.getAllWindows();
-    log.warn(`[Auth] Notifying ${wins.length} window(s) of bridge fallback: ${message}`);
-    wins.forEach(w => {
-        if (!w.isDestroyed() && !w.webContents.isDestroyed()) {
-            try {
-                w.webContents.send('auth:bridge-warning', { message });
-            } catch (err) {
-                log.warn(`[Auth] Failed to send auth bridge warning: ${err}`);
-            }
-        }
-    });
-}
-
 export function registerAuthHandlers() {
     ipcMain.handle('auth:login-google', async () => {
         // NOTE: Explicitly disconnected from the external landing/login bridge.
@@ -189,37 +175,6 @@ export function registerAuthHandlers() {
         // cross-app handoff failures and stuck loading states.
         log.warn('[Auth] auth:login-google IPC called, but external login bridge is disabled. Use renderer Firebase auth flow.');
         return { ok: false, reason: 'external-login-bridge-disabled' };
-        const enableBridgeFallback = process.env.INDIIOS_ENABLE_LOGIN_BRIDGE === 'true';
-        const LOGIN_BRIDGE_URL = process.env.VITE_LANDING_PAGE_URL;
-
-        if (enableBridgeFallback && LOGIN_BRIDGE_URL) {
-            const bridgeWarning = 'Google login is using the web login bridge fallback.';
-            log.warn(`[Auth] ${bridgeWarning} URL: ${LOGIN_BRIDGE_URL}`);
-            notifyBridgeWarning(bridgeWarning);
-            await shell.openExternal(LOGIN_BRIDGE_URL);
-            return { mode: 'bridge' };
-        }
-
-        if (enableBridgeFallback && !LOGIN_BRIDGE_URL) {
-            const errorMessage = 'Web login bridge fallback is enabled but VITE_LANDING_PAGE_URL is missing.';
-            log.error(`[Auth] ${errorMessage}`);
-            notifyAuthError(errorMessage);
-            return { mode: 'error', message: errorMessage };
-        }
-
-        log.info('[Auth] Starting native desktop Google OAuth flow.');
-        const wins = BrowserWindow.getAllWindows();
-        wins.forEach(w => {
-            if (!w.isDestroyed() && !w.webContents.isDestroyed()) {
-                try {
-                    w.webContents.send('auth:begin-native-google');
-                } catch (err) {
-                    log.warn(`[Auth] Failed to signal native Google auth start: ${err}`);
-                }
-            }
-        });
-
-        return { mode: 'native' };
     });
 
     ipcMain.handle('auth:complete-native-google', async (_event, payload: { idToken?: string; accessToken?: string | null; error?: string }) => {


### PR DESCRIPTION
### Motivation
- Fix a P1 regression where `shell` was removed from imports while the unreachable login bridge fallback still referenced `shell.openExternal`, causing `TS2304` typecheck failures for `packages/main`.
- Ensure the main process build and typechecking remain green while preserving the explicit disabled-bridge behavior for Google login.

### Description
- Removed the unused `notifyBridgeWarning` helper from `packages/main/src/handlers/auth.ts` to eliminate bridge-specific signaling no longer needed.
- Deleted the stale/unreachable bridge fallback block inside `ipcMain.handle('auth:login-google')`, removing the `shell.openExternal(...)` reference and related environment checks.
- Preserved the early return `return { ok: false, reason: 'external-login-bridge-disabled' }` to keep the handler explicitly disabled for external login bridge handoff.

### Testing
- Ran `npm run -s typecheck:main` and it passed successfully after the changes.
- Pre-commit tasks (ESLint/format hooks) executed as part of the commit and completed without errors.
- Verified the updated file was committed (`git commit` succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4a1e709c8832db2f466845e82dcaa)