### PR TITLE
Fix desktop auth fallback when handoff env vars are unset

### DIFF
--- a/packages/landing/src/login-bridge/page.tsx
+++ b/packages/landing/src/login-bridge/page.tsx
@@ -1,12 +1,18 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
-import { getAuth, GoogleAuthProvider, signInWithPopup, onAuthStateChanged } from 'firebase/auth';
+import { getAuth, GoogleAuthProvider, onAuthStateChanged, signInWithPopup } from 'firebase/auth';
 import app from '../lib/firebase';
 
 type Status = 'loading' | 'ready' | 'authenticating' | 'success' | 'deepLinkFallback' | 'error';
 
 const DEEP_LINK_TIMEOUT_MS = 3000;
+
+type CallbackPayload = {
+    code?: string;
+    idToken?: string;
+    accessToken?: string | null;
+};
 
 export default function LoginBridge() {
     const [status, setStatus] = useState<Status>('loading');
@@ -34,12 +40,22 @@ export default function LoginBridge() {
         };
     }, []);
 
-    const redirectToApp = (code: string) => {
+    const redirectToApp = ({ code, idToken, accessToken }: CallbackPayload) => {
         setStatus('success');
         setError(null);
         try {
             const params = new URLSearchParams();
-            params.append('code', code);
+            if (code) {
+                params.append('code', code);
+            } else {
+                if (!idToken) {
+                    throw new Error('Missing auth callback payload');
+                }
+                params.append('idToken', idToken);
+                if (accessToken) {
+                    params.append('accessToken', accessToken);
+                }
+            }
 
             const callbackUrl = `indii-os://auth/callback?${params.toString()}`;
             setCallbackPackage(callbackUrl);
@@ -71,11 +87,14 @@ export default function LoginBridge() {
             setError('Could not copy callback token package. Please retry and keep this page open.');
             setStatus('error');
         }
+    };
 
-
-    const createDesktopHandoffCode = async (idToken: string, accessToken?: string | null): Promise<string> => {
+    const createDesktopHandoffCode = async (idToken: string, accessToken?: string | null): Promise<string | null> => {
         const endpoint = process.env.NEXT_PUBLIC_AUTH_HANDOFF_URL;
-        if (!endpoint) throw new Error('Auth handoff service is not configured');
+        if (!endpoint) {
+            console.warn('Auth handoff service URL is not configured; falling back to legacy callback payload');
+            return null;
+        }
 
         const response = await fetch(endpoint, {
             method: 'POST',
@@ -87,7 +106,7 @@ export default function LoginBridge() {
             throw new Error(`Failed to create handoff code (${response.status})`);
         }
 
-        const data = await response.json() as { code?: string };
+        const data = (await response.json()) as { code?: string };
         if (!data.code) throw new Error('Handoff service did not return a code');
 
         return data.code;
@@ -112,7 +131,11 @@ export default function LoginBridge() {
             }
 
             const handoffCode = await createDesktopHandoffCode(credential.idToken, credential.accessToken);
-            redirectToApp(handoffCode);
+            if (handoffCode) {
+                redirectToApp({ code: handoffCode });
+            } else {
+                redirectToApp({ idToken: credential.idToken, accessToken: credential.accessToken });
+            }
         } catch (err: any) {
             console.error('Google Sign-In Error:', err);
             const code = err?.code || '';
@@ -133,6 +156,7 @@ export default function LoginBridge() {
                     <h1 className="text-2xl font-bold mb-2">indiiOS</h1>
                     <p className="text-neutral-400 text-sm">Sign in to continue to the app</p>
                 </div>
+
 
                 {status === 'loading' && (
                     <div className="flex items-center justify-center py-8">
@@ -175,6 +199,7 @@ export default function LoginBridge() {
                 )}
 
                 <div className="mt-6 pt-6 border-t border-neutral-800"><p className="text-neutral-500 text-xs">This page authenticates you with Google and redirects back to the indiiOS desktop app.</p></div>
+
             </div>
         </div>
     );

--- a/packages/main/src/handlers/auth.ts
+++ b/packages/main/src/handlers/auth.ts
@@ -180,8 +180,7 @@ function notifyBridgeWarning(message: string) {
             }
         }
     });
-
-
+}
 
 function isLegacyCallbackEnabled(): boolean {
     return process.env.AUTH_ALLOW_LEGACY_TOKEN_CALLBACK === 'true';
@@ -207,7 +206,7 @@ function markCodeAsConsumed(code: string) {
     }
 }
 
-async function redeemDesktopHandoffCode(code: string): Promise<DesktopHandoffRedeemResult> {
+async function redeemDesktopHandoffCode(code: string): Promise<DesktopHandoffRedeemResult | null> {
     if (!code || code.length < 8) {
         throw new Error('Invalid handoff code');
     }
@@ -218,7 +217,8 @@ async function redeemDesktopHandoffCode(code: string): Promise<DesktopHandoffRed
 
     const endpoint = process.env.AUTH_HANDOFF_REDEEM_URL;
     if (!endpoint) {
-        throw new Error('Handoff redemption endpoint not configured');
+        log.warn('[Auth] AUTH_HANDOFF_REDEEM_URL is not configured; skipping handoff redemption');
+        return null;
     }
 
     const response = await fetch(endpoint, {
@@ -379,9 +379,23 @@ export async function handleDeepLink(url: string) {
             }
         } else {
             const redeemed = await redeemDesktopHandoffCode(code);
-            idToken = redeemed.idToken;
-            accessToken = redeemed.accessToken ?? null;
-            refreshToken = redeemed.refreshToken ?? null;
+            if (redeemed) {
+                idToken = redeemed.idToken;
+                accessToken = redeemed.accessToken ?? null;
+                refreshToken = redeemed.refreshToken ?? null;
+            } else if (isLegacyCallbackEnabled()) {
+                log.warn('[Auth] Falling back to legacy callback tokens because AUTH_HANDOFF_REDEEM_URL is unset');
+                idToken = urlObj.searchParams.get('idToken');
+                accessToken = urlObj.searchParams.get('accessToken');
+                refreshToken = urlObj.searchParams.get('refreshToken');
+                if (!idToken) {
+                    notifyAuthError('Authentication handoff is not configured. Please update desktop auth settings.');
+                    return;
+                }
+            } else {
+                notifyAuthError('Authentication handoff is not configured. Please contact support.');
+                return;
+            }
         }
 
         // =====================================================================


### PR DESCRIPTION
### Motivation

- Prevent desktop sign-in from hard-failing when `NEXT_PUBLIC_AUTH_HANDOFF_URL` is not configured by restoring a safe legacy fallback path from the landing page.
- Avoid making `AUTH_HANDOFF_REDEEM_URL` mandatory so deep-link `code` callbacks do not outage desktop login when the redeem endpoint is absent.
- Preserve compatibility during a staged rollout of the one-time handoff flow by allowing controlled legacy token callbacks behind a feature flag.

### Description

- Updated `packages/landing/src/login-bridge/page.tsx` so `createDesktopHandoffCode` returns `null` (with a warning) when `NEXT_PUBLIC_AUTH_HANDOFF_URL` is unset and `redirectToApp` supports either a one-time `code` payload or legacy `idToken`/`accessToken` payload.
- Updated `packages/main/src/handlers/auth.ts` so `redeemDesktopHandoffCode` returns `null` (with a warning) when `AUTH_HANDOFF_REDEEM_URL` is unset and `handleDeepLink` uses the redeemed payload when present or falls back to legacy query params only if `AUTH_ALLOW_LEGACY_TOKEN_CALLBACK` is enabled.
- Fixed a missing closure around `notifyBridgeWarning` to keep the auth handler module syntactically and functionally correct.

### Testing

- Ran the targeted handoff unit tests with `pnpm vitest run packages/main/src/handlers/auth.handoff.test.ts`, and the test file passed: **4 tests passed**.
- A workspace-wide `pnpm -w test` invocation was attempted but is not valid in this environment; targeted `vitest` invocation above was used instead and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4a413e1cc832db24df0c0704d81f8)