### PR TITLE
fix(renderer): remove inline boot watchdog blocked by CSP

### DIFF
--- a/packages/renderer/index.html
+++ b/packages/renderer/index.html
@@ -100,53 +100,6 @@
       }
     </style>
 
-    <script>
-      // Startup watchdog: avoid infinite spinner when module boot fails before React mounts.
-      (function () {
-        const BOOT_TIMEOUT_MS = 12000;
-
-        function showStartupFallback(reason) {
-          const root = document.getElementById('root');
-          if (!root || root.childElementCount > 0) return;
-
-          const webglAvailable = (() => {
-            try {
-              const canvas = document.createElement('canvas');
-              return !!(window.WebGLRenderingContext && (canvas.getContext('webgl') || canvas.getContext('experimental-webgl')));
-            } catch {
-              return false;
-            }
-          })();
-
-          root.innerHTML = `
-            <div style="display:flex;align-items:center;justify-content:center;min-height:100vh;background:#0a0a0f;color:#e4e4e7;font-family:system-ui,sans-serif;padding:2rem;text-align:center">
-              <div style="max-width:480px">
-                <h1 style="font-size:1.5rem;margin-bottom:1rem;color:#a78bfa">indiiOS</h1>
-                <p style="margin-bottom:1rem;opacity:0.85">The app took too long to start.</p>
-                <p style="margin-bottom:1.5rem;opacity:0.65;font-size:0.9rem">${reason || 'Startup error detected.'} ${webglAvailable ? '' : 'WebGL appears unavailable in this browser/device.'}</p>
-                <button onclick="location.reload()" style="background:#7c3aed;color:white;border:none;padding:0.75rem 2rem;border-radius:0.5rem;font-size:1rem;cursor:pointer">Reload App</button>
-              </div>
-            </div>`;
-        }
-
-        window.addEventListener('error', (event) => {
-          showStartupFallback(event?.message || 'Script error');
-        });
-
-        window.addEventListener('unhandledrejection', (event) => {
-          const reason = event?.reason instanceof Error ? event.reason.message : 'Unhandled startup promise rejection';
-          showStartupFallback(reason);
-        });
-
-        setTimeout(() => {
-          const root = document.getElementById('root');
-          if (root && root.childElementCount === 0) {
-            showStartupFallback('Startup timeout exceeded (12s).');
-          }
-        }, BOOT_TIMEOUT_MS);
-      })();
-    </script>
-
   </head>
   <body>
     <div id="root"></div>

--- a/packages/renderer/src/main.tsx
+++ b/packages/renderer/src/main.tsx
@@ -23,20 +23,16 @@ import { renderStartupFallback } from '@/startupFallback';
 import '@/core/i18n'; // Initialize i18n before any component renders
 import './index.css';
 
-// Import global test harness
+// Initialize observability
 import { initSentry } from '@/services/observability/SentryService';
 
-// Initialize Sentry before the app renders. 
+// Initialize Sentry before the app renders.
 // Item 303: Consent is checked internally within initSentry.
-initSentry();
-
-
 try {
     initSentry();
 } catch (error: unknown) {
     logger.warn('[Startup] Sentry initialization failed (non-blocking):', error);
 }
-
 
 logger.debug("Indii OS Studio v1.2.6-manual-redeploy");
 document.title = "indiiOS - Studio (v1.2.6)";


### PR DESCRIPTION
The boot watchdog from #1632 was kept as an inline <script> in index.html, which the production CSP blocks (script-src 'self' 'wasm-unsafe-eval'). Result: when startup actually fails (e.g. vendor-three crash on the deployed app), the watchdog never runs, the CSS spinner traps the user, and there is no Reload button.

#1633 already shipped the external module replacement at src/startupWatchdog.ts and wired it into the body, but left the inline copy in the head. Drop the inline copy so the module-based watchdog actually runs in production. Also wrap initSentry() in try/catch so a Sentry init blow-up cannot kill startup.

Does NOT fix the underlying vendor-three crash — that is a separate ESM circular-chunk issue still under investigation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized startup initialization code structure.

* **Bug Fixes**
  * Improved error handling during application startup to prevent initialization conflicts and ensure consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->