### PR TITLE
Add optional handoff-code flow with legacy token fallback for login bridge and auth handler

### DIFF
--- a/packages/landing/src/login-bridge/page.tsx
+++ b/packages/landing/src/login-bridge/page.tsx
@@ -1,12 +1,18 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
-import { getAuth, GoogleAuthProvider, signInWithPopup, onAuthStateChanged } from 'firebase/auth';
+import { getAuth, GoogleAuthProvider, onAuthStateChanged, signInWithPopup } from 'firebase/auth';
 import app from '../lib/firebase';
 
 type Status = 'loading' | 'ready' | 'authenticating' | 'success' | 'deepLinkFallback' | 'error';
 
 const DEEP_LINK_TIMEOUT_MS = 3000;
+
+type CallbackPayload = {
+    code?: string;
+    idToken?: string;
+    accessToken?: string | null;
+};
 
 export default function LoginBridge() {
     const [status, setStatus] = useState<Status>('loading');
@@ -34,12 +40,22 @@ export default function LoginBridge() {
         };
     }, []);
 
-    const redirectToApp = (code: string) => {
+    const redirectToApp = ({ code, idToken, accessToken }: CallbackPayload) => {
         setStatus('success');
         setError(null);
         try {
             const params = new URLSearchParams();
-            params.append('code', code);
+            if (code) {
+                params.append('code', code);
+            } else {
+                if (!idToken) {
+                    throw new Error('Missing auth callback payload');
+                }
+                params.append('idToken', idToken);
+                if (accessToken) {
+                    params.append('accessToken', accessToken);
+                }
+            }
 
             const callbackUrl = `indii-os://auth/callback?${params.toString()}`;
             setCallbackPackage(callbackUrl);
@@ -71,11 +87,14 @@ export default function LoginBridge() {
             setError('Could not copy callback token package. Please retry and keep this page open.');
             setStatus('error');
         }
+    };
 
-
-    const createDesktopHandoffCode = async (idToken: string, accessToken?: string | null): Promise<string> => {
+    const createDesktopHandoffCode = async (idToken: string, accessToken?: string | null): Promise<string | null> => {
         const endpoint = process.env.NEXT_PUBLIC_AUTH_HANDOFF_URL;
-        if (!endpoint) throw new Error('Auth handoff service is not configured');
+        if (!endpoint) {
+            console.warn('Auth handoff service URL is not configured; falling back to legacy callback payload');
+            return null;
+        }
 
         const response = await fetch(endpoint, {
             method: 'POST',
@@ -87,7 +106,7 @@ export default function LoginBridge() {
             throw new Error(`Failed to create handoff code (${response.status})`);
         }
 
-        const data = await response.json() as { code?: string };
+        const data = (await response.json()) as { code?: string };
         if (!data.code) throw new Error('Handoff service did not return a code');
 
         return data.code;
@@ -112,16 +131,21 @@ export default function LoginBridge() {
             }
 
             const handoffCode = await createDesktopHandoffCode(credential.idToken, credential.accessToken);
-            redirectToApp(handoffCode);
-        } catch (err: any) {
+            if (handoffCode) {
+                redirectToApp({ code: handoffCode });
+            } else {
+                redirectToApp({ idToken: credential.idToken, accessToken: credential.accessToken });
+            }
+        } catch (err: unknown) {
             console.error('Google Sign-In Error:', err);
-            const code = err?.code || '';
+            const code = typeof err === 'object' && err && 'code' in err ? String((err as { code?: string }).code ?? '') : '';
             if (code === 'auth/popup-closed-by-user' || code === 'auth/popup-blocked') {
                 setError('Sign-in popup was closed or blocked. Allow popups for this site and try again.');
                 setStatus('ready');
                 return;
             }
-            setError(err.message || 'Google sign-in failed');
+            const message = typeof err === 'object' && err && 'message' in err ? String((err as { message?: string }).message ?? '') : '';
+            setError(message || 'Google sign-in failed');
             setStatus('error');
         }
     };
@@ -133,6 +157,7 @@ export default function LoginBridge() {
                     <h1 className="text-2xl font-bold mb-2">indiiOS</h1>
                     <p className="text-neutral-400 text-sm">Sign in to continue to the app</p>
                 </div>
+
 
                 {status === 'loading' && (
                     <div className="flex items-center justify-center py-8">
@@ -175,6 +200,7 @@ export default function LoginBridge() {
                 )}
 
                 <div className="mt-6 pt-6 border-t border-neutral-800"><p className="text-neutral-500 text-xs">This page authenticates you with Google and redirects back to the indiiOS desktop app.</p></div>
+
             </div>
         </div>
     );

--- a/packages/main/src/handlers/auth.ts
+++ b/packages/main/src/handlers/auth.ts
@@ -180,11 +180,19 @@ function notifyBridgeWarning(message: string) {
             }
         }
     });
-
-
+}
 
 function isLegacyCallbackEnabled(): boolean {
-    return process.env.AUTH_ALLOW_LEGACY_TOKEN_CALLBACK === 'true';
+    if (process.env.AUTH_ALLOW_LEGACY_TOKEN_CALLBACK === 'true') {
+        return true;
+    }
+
+    if (!process.env.AUTH_HANDOFF_REDEEM_URL) {
+        log.warn('[Auth] Legacy callback compatibility is temporarily enabled because AUTH_HANDOFF_REDEEM_URL is not configured');
+        return true;
+    }
+
+    return false;
 }
 
 type DesktopHandoffRedeemResult = {
@@ -207,7 +215,7 @@ function markCodeAsConsumed(code: string) {
     }
 }
 
-async function redeemDesktopHandoffCode(code: string): Promise<DesktopHandoffRedeemResult> {
+async function redeemDesktopHandoffCode(code: string): Promise<DesktopHandoffRedeemResult | null> {
     if (!code || code.length < 8) {
         throw new Error('Invalid handoff code');
     }
@@ -218,7 +226,8 @@ async function redeemDesktopHandoffCode(code: string): Promise<DesktopHandoffRed
 
     const endpoint = process.env.AUTH_HANDOFF_REDEEM_URL;
     if (!endpoint) {
-        throw new Error('Handoff redemption endpoint not configured');
+        log.warn('[Auth] AUTH_HANDOFF_REDEEM_URL is not configured; skipping handoff redemption');
+        return null;
     }
 
     const response = await fetch(endpoint, {
@@ -379,9 +388,23 @@ export async function handleDeepLink(url: string) {
             }
         } else {
             const redeemed = await redeemDesktopHandoffCode(code);
-            idToken = redeemed.idToken;
-            accessToken = redeemed.accessToken ?? null;
-            refreshToken = redeemed.refreshToken ?? null;
+            if (redeemed) {
+                idToken = redeemed.idToken;
+                accessToken = redeemed.accessToken ?? null;
+                refreshToken = redeemed.refreshToken ?? null;
+            } else if (isLegacyCallbackEnabled()) {
+                log.warn('[Auth] Falling back to legacy callback tokens because AUTH_HANDOFF_REDEEM_URL is unset');
+                idToken = urlObj.searchParams.get('idToken');
+                accessToken = urlObj.searchParams.get('accessToken');
+                refreshToken = urlObj.searchParams.get('refreshToken');
+                if (!idToken) {
+                    notifyAuthError('Authentication handoff is not configured. Please update desktop auth settings.');
+                    return;
+                }
+            } else {
+                notifyAuthError('Authentication handoff is not configured. Please contact support.');
+                return;
+            }
         }
 
         // =====================================================================


### PR DESCRIPTION
### Motivation
- Introduce a one-time handoff code flow for desktop auth while preserving a legacy idToken/accessToken callback fallback when the handoff service is not configured or temporarily disabled.
- Improve robustness of the login bridge and main auth handler to handle missing configuration and unknown runtime errors gracefully.

### Description
- Change the login bridge to accept a `CallbackPayload` object and build the deep-link URL using either a one-time `code` or `idToken`/`accessToken` pair, and expose the callback package for copy/open fallback.
- Make `createDesktopHandoffCode` return `null` (and log a warning) when `NEXT_PUBLIC_AUTH_HANDOFF_URL` is not configured, and update `handleGoogleSignIn` to use the handoff `code` when present or fall back to sending tokens directly; also tighten error extraction from caught exceptions.
- Add `isLegacyCallbackEnabled` to the main auth handler which enables legacy token callbacks when `AUTH_ALLOW_LEGACY_TOKEN_CALLBACK` is `true` or `AUTH_HANDOFF_REDEEM_URL` is missing, change `redeemDesktopHandoffCode` to return `null` when redemption endpoint is absent, and update `handleDeepLink` to fall back to legacy token parameters when appropriate or surface a clear auth error when not.
- Miscellaneous safety and UI cleanup tweaks (minor import reorder, stricter types, and additional logging).

### Testing
- Ran TypeScript type-check/build (`tsc`/project build) against the modified packages which completed successfully.
- Ran the repository's existing automated test suite for auth-related code (unit/integration tests) and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4a413e1cc832db24df0c0704d81f8)