### PR TITLE
Avoid double-initialization of Sentry in renderer startup

### DIFF
--- a/packages/renderer/src/main.tsx
+++ b/packages/renderer/src/main.tsx
@@ -23,20 +23,16 @@ import { renderStartupFallback } from '@/startupFallback';
 import '@/core/i18n'; // Initialize i18n before any component renders
 import './index.css';
 
-// Import global test harness
+// Initialize observability
 import { initSentry } from '@/services/observability/SentryService';
 
-// Initialize Sentry before the app renders. 
+// Initialize Sentry before the app renders.
 // Item 303: Consent is checked internally within initSentry.
-initSentry();
-
-
 try {
     initSentry();
 } catch (error: unknown) {
     logger.warn('[Startup] Sentry initialization failed (non-blocking):', error);
 }
-
 
 logger.debug("Indii OS Studio v1.2.6-manual-redeploy");
 document.title = "indiiOS - Studio (v1.2.6)";


### PR DESCRIPTION
### Motivation
- Prevent duplicate initialization of the observability/Sentry service during renderer startup and clarify intent in comments. 

### Description
- Remove the redundant top-level `initSentry()` call so Sentry is only initialized once inside the `try { initSentry(); } catch (...) { ... }` block and update the surrounding comment to `Initialize observability`.

### Testing
- Ran TypeScript type-check with `tsc --noEmit` and started the dev renderer to verify the app mounts; both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4a3b952a0832db3176142a9ef33ce)