### PR TITLE
Add feature flag to enable/disable Google Maps and propagate through env, components and services

### DIFF
--- a/packages/renderer/src/config/env.ts
+++ b/packages/renderer/src/config/env.ts
@@ -12,6 +12,7 @@ const FrontendEnvSchema = CommonEnvSchema.extend({
     VITE_FUNCTIONS_URL: z.string().url().optional(),
     VITE_RAG_PROXY_URL: z.union([z.string().url(), z.literal('')]).optional(),
     VITE_GOOGLE_MAPS_API_KEY: z.string().optional(),
+    VITE_ENABLE_GOOGLE_MAPS: z.string().optional(),
     DEV: z.boolean().default(false),
 
     // Firebase specific overrides (optional)
@@ -35,6 +36,7 @@ const FrontendEnvSchema = CommonEnvSchema.extend({
     VITE_EXPOSE_INTERNALS: z.string().optional(),
 
     skipOnboarding: z.boolean().default(false),
+    enableGoogleMaps: z.boolean().default(true),
 });
 
 // Initial test env detection removed to fix duplicate declaration
@@ -80,6 +82,10 @@ const processEnv = {
     location: getEnv(getSafeMetaEnv('VITE_VERTEX_LOCATION'), getProcessEnv('VITE_VERTEX_LOCATION')) || "us-central1",
     useVertex: toBoolean(getSafeMetaEnv('VITE_USE_VERTEX') || getProcessEnv('VITE_USE_VERTEX')),
     googleMapsApiKey: getEnv(getSafeMetaEnv('VITE_GOOGLE_MAPS_API_KEY'), getProcessEnv('VITE_GOOGLE_MAPS_API_KEY')),
+    enableGoogleMaps: (() => {
+        const raw = getEnv(getSafeMetaEnv('VITE_ENABLE_GOOGLE_MAPS'), getProcessEnv('VITE_ENABLE_GOOGLE_MAPS'));
+        return raw === undefined ? true : toBoolean(raw);
+    })(),
 
     VITE_FUNCTIONS_URL: getEnv(getSafeMetaEnv('VITE_FUNCTIONS_URL'), getProcessEnv('VITE_FUNCTIONS_URL')),
     VITE_RAG_PROXY_URL: getEnv(getSafeMetaEnv('VITE_RAG_PROXY_URL'), getProcessEnv('VITE_RAG_PROXY_URL')),
@@ -140,6 +146,7 @@ export const env = {
     VITE_VERTEX_PROJECT_ID: runtimeEnv.projectId,
     VITE_VERTEX_LOCATION: runtimeEnv.location,
     VITE_USE_VERTEX: runtimeEnv.useVertex,
+    enableGoogleMaps: runtimeEnv.enableGoogleMaps,
     appCheckKey: processEnv.appCheckKey,
     appCheckDebugToken: processEnv.appCheckDebugToken,
 };

--- a/packages/renderer/src/modules/marketing/components/MapsComponent.tsx
+++ b/packages/renderer/src/modules/marketing/components/MapsComponent.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { Wrapper, Status } from '@googlemaps/react-wrapper';
+import { env } from '@/config/env';
 
 const render = (status: Status) => {
     if (status === Status.LOADING) return <div className="h-full w-full flex items-center justify-center bg-gray-900 text-gray-500">Loading Maps...</div>;
@@ -62,14 +63,22 @@ const Map: React.FC<MapProps> = ({ center, zoom, markers }) => {
 };
 
 export default function MapsComponent() {
-    // Default to a placeholder if no key is present, to avoid crashing in dev without key
-    const apiKey = import.meta.env.VITE_GOOGLE_MAPS_KEY || '';
+    const apiKey = env.googleMapsApiKey || '';
+
+    if (!env.enableGoogleMaps) {
+        return (
+            <div className="w-full h-full bg-gray-900 rounded-xl flex flex-col items-center justify-center text-gray-500 p-6 text-center border border-gray-800">
+                <p className="mb-2 font-medium text-gray-400">Google Maps Integration</p>
+                <p className="text-sm">Google Maps is disabled by feature flag (VITE_ENABLE_GOOGLE_MAPS=false).</p>
+            </div>
+        );
+    }
 
     if (!apiKey) {
         return (
             <div className="w-full h-full bg-gray-900 rounded-xl flex flex-col items-center justify-center text-gray-500 p-6 text-center border border-gray-800">
                 <p className="mb-2 font-medium text-gray-400">Google Maps Integration</p>
-                <p className="text-sm">Add VITE_GOOGLE_MAPS_KEY to .env to enable live campaign tracking.</p>
+                <p className="text-sm">Add VITE_GOOGLE_MAPS_API_KEY to .env to enable live campaign tracking.</p>
             </div>
         );
     }

--- a/packages/renderer/src/modules/touring/components/TourMap.tsx
+++ b/packages/renderer/src/modules/touring/components/TourMap.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef, useState, useCallback } from 'react';
 import { Wrapper, Status } from "@googlemaps/react-wrapper";
 import { Loader2, MapPinOff, Map as MapIcon } from 'lucide-react';
 import { logger } from '@/utils/logger';
+import { env } from '@/config/env';
 
 import { MapMarker } from '../types';
 
@@ -13,7 +14,7 @@ interface TourMapProps {
 }
 
 // ─── Graceful Map Unavailable Fallback ─────────────────────────────────────────
-const MapUnavailableFallback: React.FC<{ reason: 'missing_key' | 'auth_failure' | 'load_failure' }> = ({ reason }) => {
+const MapUnavailableFallback: React.FC<{ reason: 'missing_key' | 'auth_failure' | 'load_failure' | 'feature_disabled' }> = ({ reason }) => {
     const messages: Record<string, { title: string; detail: string }> = {
         missing_key: {
             title: 'Map Visualization Disabled',
@@ -26,6 +27,10 @@ const MapUnavailableFallback: React.FC<{ reason: 'missing_key' | 'auth_failure' 
         load_failure: {
             title: 'Map Could Not Load',
             detail: 'Google Maps failed to initialize. Check your API key and ensure the Maps JavaScript API is enabled.',
+        },
+        feature_disabled: {
+            title: 'Map Visualization Disabled',
+            detail: 'Google Maps is currently disabled by feature flag (VITE_ENABLE_GOOGLE_MAPS=false).',
         },
     };
 
@@ -318,12 +323,16 @@ const MapComponent: React.FC<TourMapProps & { onAuthFailure: () => void }> = ({ 
 
 // ─── TourMap Wrapper ───────────────────────────────────────────────────────────
 export const TourMap: React.FC<TourMapProps> = (props) => {
-    const apiKey = import.meta.env.VITE_GOOGLE_MAPS_API_KEY;
+    const apiKey = env.googleMapsApiKey;
     const [authFailed, setAuthFailed] = useState(false);
 
     const handleAuthFailure = useCallback(() => {
         setAuthFailed(true);
     }, []);
+
+    if (!env.enableGoogleMaps) {
+        return <MapUnavailableFallback reason="feature_disabled" />;
+    }
 
     // No API key at all — show clean fallback
     if (!apiKey) {

--- a/packages/renderer/src/services/agent/tools/MapsTools.ts
+++ b/packages/renderer/src/services/agent/tools/MapsTools.ts
@@ -9,6 +9,10 @@ const loadGoogleMaps = (): Promise<void> => {
     if (mapsPromise) return mapsPromise;
 
     mapsPromise = new Promise((resolve, reject) => {
+        if (!env.enableGoogleMaps) {
+            reject(new Error("Google Maps is disabled by feature flag (VITE_ENABLE_GOOGLE_MAPS=false)"));
+            return;
+        }
         if (typeof window === 'undefined') {
             reject(new Error("Browser environment required for Google Maps API"));
             return;

--- a/packages/renderer/src/services/agent/tools/__tests__/MapsTools.test.ts
+++ b/packages/renderer/src/services/agent/tools/__tests__/MapsTools.test.ts
@@ -4,7 +4,8 @@ import { MapsTools } from '../MapsTools';
 // Mock env
 vi.mock('@/config/env', () => ({
     env: {
-        googleMapsApiKey: 'TEST_API_KEY'
+        googleMapsApiKey: 'TEST_API_KEY',
+        enableGoogleMaps: true,
     }
 }));
 

--- a/packages/renderer/src/services/places/NearbyPlacesService.ts
+++ b/packages/renderer/src/services/places/NearbyPlacesService.ts
@@ -67,6 +67,9 @@ const ensureGoogleMapsLoaded = (): Promise<void> => {
     if (mapsLoadPromise) return mapsLoadPromise;
 
     mapsLoadPromise = (async () => {
+        if (!env.enableGoogleMaps) {
+            throw new Error('Google Maps is disabled by feature flag (VITE_ENABLE_GOOGLE_MAPS=false)');
+        }
         if (typeof window === 'undefined') {
             throw new Error('Browser environment required for Google Maps API');
         }


### PR DESCRIPTION
### Motivation

- Provide a runtime feature flag to globally enable or disable Google Maps integration so the app can run without a Maps API key or when Maps should be turned off. 

### Description

- Add `VITE_ENABLE_GOOGLE_MAPS` to the frontend env schema and expose `enableGoogleMaps` on the runtime `env` with a default of `true`. 
- Use `env.googleMapsApiKey` and `env.enableGoogleMaps` in the Maps UI components (`MapsComponent`, `TourMap`) to show a clear disabled/fallback UI when Maps are turned off or the API key is missing. 
- Make runtime loaders/services (`MapsTools`, `NearbyPlacesService`) bail early and return/reject with a clear error when `enableGoogleMaps` is `false`. 
- Update unit test mocks to include `enableGoogleMaps` and correct the Google Maps API env variable name to `VITE_GOOGLE_MAPS_API_KEY` usage where applicable. 

### Testing

- Ran unit tests with `vitest`, including the `MapsTools` tests, which passed. 
- Verified that the Maps components render the disabled/fallback UI when `env.enableGoogleMaps` is `false` in local testing. 
- Confirmed no regressions in the updated unit tests after adding the feature flag to the env mock.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4a464cb08832db053515b94643ade)