### PR TITLE
fix: update ISRC routing from publishing to music agent

### DIFF
--- a/agents/agent0/prompt.md
+++ b/agents/agent0/prompt.md
@@ -59,7 +59,7 @@ When a query could match multiple Spokes, apply these tiebreakers:
 
 ## CRITICAL PROTOCOLS
 
-1. **Never Hallucinate Specialized Advice:** Route contract law to Legal, accounting to Finance, ISRC to Publishing, etc. ALWAYS use the `delegate_task` tool instead of answering directly.
+1. **Never Hallucinate Specialized Advice:** Route contract law to Legal, accounting to Finance, ISRC to Music, etc. ALWAYS use the `delegate_task` tool instead of answering directly.
 2. **Context Passing:** Pass the *exact* context the Spoke agent needs.
 3. **The User is the Executive Producer:** Bring them decisions, not just open questions.
 4. **Mandatory Tool Execution:** When you decide to delegate, you MUST actually execute the `delegate_task` function via the tool API. Never output a text response claiming you have delegated a task without actually triggering the tool call. Do NOT write out the tool call in plain text.

--- a/optimization/autoagent/results.tsv
+++ b/optimization/autoagent/results.tsv
@@ -45,3 +45,11 @@ abf098f	1.0	26	26	baseline	baseline
 4f2bc56	1.0	26	26	baseline	baseline
 4f2bc56	1.0	26	26	baseline	baseline
 4f2bc56	1.0	26	26	baseline	Routing ISRC to Music
+b5ac484	1.0	26	26	baseline	baseline
+b5ac484	1.0	26	26	baseline	baseline
+b5ac484	1.0	26	26	baseline	baseline
+b5ac484	1.0	26	26	baseline	baseline
+b5ac484	1.0	26	26	baseline	baseline
+b5ac484	1.0	26	26	baseline	baseline
+b5ac484	1.0	26	26	baseline	baseline
+b5ac484	1.0	26	26	baseline	baseline

--- a/optimization/autoagent/tasks/routing-isrc.json
+++ b/optimization/autoagent/tasks/routing-isrc.json
@@ -1,6 +1,6 @@
 {
     "type": "routing",
     "input": "I just finished mastering my new single. How do I register it for an ISRC code so I can get paid when it streams?",
-    "expected_agent": "publishing",
-    "description": "Conductor must route an ISRC registration question to the publishing specialist."
+    "expected_agent": "music",
+    "description": "Conductor must route an ISRC registration question to the music specialist."
 }

--- a/packages/firebase/src/relay/agentPrompts.ts
+++ b/packages/firebase/src/relay/agentPrompts.ts
@@ -76,7 +76,7 @@ When a query could match multiple Spokes, apply these tiebreakers:
 
 ## CRITICAL PROTOCOLS
 
-1. **Never Hallucinate Specialized Advice:** Route contract law to Legal, accounting to Finance, ISRC to Publishing, etc. ALWAYS use the \`delegate_task\` tool instead of answering directly.
+1. **Never Hallucinate Specialized Advice:** Route contract law to Legal, accounting to Finance, ISRC to Music, etc. ALWAYS use the \`delegate_task\` tool instead of answering directly.
 2. **Context Passing:** Pass the *exact* context the Spoke agent needs.
 3. **The User is the Executive Producer:** Bring them decisions, not just open questions.
 4. **Mandatory Tool Execution:** When you decide to delegate, you MUST actually execute the \`delegate_task\` function via the tool API. Never output a text response claiming you have delegated a task without actually triggering the tool call. Do NOT write out the tool call in plain text.


### PR DESCRIPTION
This change updates the `ISRC` routing logic in the Conductor's prompts to point correctly to the `music` agent instead of `publishing`. It also aligns the `routing-isrc.json` evaluation task to expect `music` for accuracy, and successfully passes the `eval.py` loop.

---
*PR created automatically by Jules for task [17508597645247913202](https://jules.google.com/task/17508597645247913202) started by @the-walking-agency-det*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated request routing to direct ISRC registration inquiries to the Music specialist team for improved handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->