### PR TITLE
Fix ISRC routing ambiguity in Conductor prompt

### DIFF
--- a/agents/agent0/prompt.md
+++ b/agents/agent0/prompt.md
@@ -54,7 +54,7 @@ When a query could match multiple Spokes, apply these tiebreakers:
 ### delegate_task
 
 **When to use:** A user request requires specialized knowledge or action from a Spoke agent. You MUST use this tool to route tasks.
-**Example call:** `delegate_task({ targetAgentId: "publishing", task: "Assign an ISRC code to the new track." })`
+**Example call:** `delegate_task({ targetAgentId: "music", task: "Assign an ISRC code to the new track." })`
 **Returns:** The specialized agent's final output or status report.
 
 ## CRITICAL PROTOCOLS

--- a/packages/firebase/src/relay/agentPrompts.ts
+++ b/packages/firebase/src/relay/agentPrompts.ts
@@ -71,7 +71,7 @@ When a query could match multiple Spokes, apply these tiebreakers:
 ### delegate_task
 
 **When to use:** A user request requires specialized knowledge or action from a Spoke agent. You MUST use this tool to route tasks.
-**Example call:** \`delegate_task({ targetAgentId: "publishing", task: "Assign an ISRC code to the new track." })\`
+**Example call:** \`delegate_task({ targetAgentId: "music", task: "Assign an ISRC code to the new track." })\`
 **Returns:** The specialized agent's final output or status report.
 
 ## CRITICAL PROTOCOLS


### PR DESCRIPTION
This commit corrects an issue where the `indii Conductor`'s routing example incorrectly mapped ISRC tasks to the `publishing` agent. By updating the target agent to `music`, it resolves the test failure in `routing-isrc.json`. The `packages/firebase/src/relay/agentPrompts.ts` file has also been updated to ensure consistency across the codebase.

---
*PR created automatically by Jules for task [6516036112694473786](https://jules.google.com/task/6516036112694473786) started by @the-walking-agency-det*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated agent task routing examples to direct ISRC code assignment requests to the music agent instead of the publishing agent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->