### PR TITLE
⚡ Bolt: Hoist Timestamp.now() out of loops in AlwaysOnMemoryEngine

### DIFF
--- a/packages/renderer/src/services/agent/AlwaysOnMemoryEngine.ts
+++ b/packages/renderer/src/services/agent/AlwaysOnMemoryEngine.ts
@@ -506,6 +506,7 @@ Be thorough but concise. Always cite your sources.`;
             const insightId = await insightService.add(insightData);
 
             // Update connections on source memories
+            const nowTimestamp = Timestamp.now();
             for (const conn of insightData.connections) {
                 for (const memoryId of [conn.fromMemoryId, conn.toMemoryId]) {
                     const memory = batch.find((m) => m.id === memoryId);
@@ -516,7 +517,7 @@ Be thorough but concise. Always cite your sources.`;
                         await service.update(memoryId, {
                             connections: updatedConnections,
                             relatedMemoryIds: updatedRelated,
-                            updatedAt: Timestamp.now(),
+                            updatedAt: nowTimestamp,
                         } as Partial<AlwaysOnMemory>);
                     }
                 }
@@ -610,6 +611,7 @@ Be thorough but concise. Always cite your sources.`;
         const tierConfig = this.config.tiers;
         let promoted = 0;
 
+        const nowTimestamp = Timestamp.now();
         for (const memory of memories) {
             if (!memory.isActive) continue;
             const age = now - memory.createdAt.toMillis();
@@ -639,7 +641,7 @@ Be thorough but concise. Always cite your sources.`;
             if (newTier && newTier !== memory.tier) {
                 await service.update(memory.id, {
                     tier: newTier,
-                    updatedAt: Timestamp.now(),
+                    updatedAt: nowTimestamp,
                 } as Partial<AlwaysOnMemory>);
                 promoted++;
             }
@@ -669,6 +671,7 @@ Be thorough but concise. Always cite your sources.`;
         const archivalThreshold = this.config.consolidation.archivalImportanceThreshold;
         let updated = 0;
 
+        const nowTimestamp = Timestamp.now();
         for (const memory of memories) {
             if (!memory.isActive) continue;
 
@@ -683,7 +686,7 @@ Be thorough but concise. Always cite your sources.`;
             if (newImportance !== memory.importance) {
                 const updates: Partial<AlwaysOnMemory> = {
                     importance: newImportance,
-                    updatedAt: Timestamp.now(),
+                    updatedAt: nowTimestamp,
                 };
 
                 // Archive if below threshold


### PR DESCRIPTION
## ⚡ Bolt: Hoist Timestamp.now() out of loops in AlwaysOnMemoryEngine

### 💡 What: 
Hoisted `Timestamp.now()` instantiation outside the execution loops in `AlwaysOnMemoryEngine.ts` (`processInsights`, `evaluateTiers`, `decayMemories`).

### 🎯 Why: 
Initializing class instances like `Timestamp.now()` inside iterative loops results in unnecessary object allocations and method calls per iteration. By hoisting the instantiation outside the loop, we eliminate this overhead during background consolidation/tier-evaluation tasks that iterate over multiple memory documents. Furthermore, it strictly enforces that all documents updated within the same logical batch receive the exact same timestamp, preventing race conditions or inconsistent sort orders based on nanosecond differences. 

### 📊 Impact: 
Reduces memory allocation overhead and CPU cycle waste during background memory processing tasks, leading to more predictable performance over large document sets.

### 🔬 Measurement: 
- Ran `npm run typecheck`
- Verified test suite passes: `npx vitest@4.1.5 run packages/renderer/src/services/agent/AlwaysOnMemoryEngine.test.ts`

---
*PR created automatically by Jules for task [5647297595568828388](https://jules.google.com/task/5647297595568828388) started by @the-walking-agency-det*