### PR TITLE
fix: route ISRC to Music instead of Publishing in AutoAgent tests

### DIFF
--- a/optimization/autoagent/eval.py
+++ b/optimization/autoagent/eval.py
@@ -61,7 +61,7 @@ ROUTING_TABLE = {
     ],
     "music": [
         "audio analysis", "mix feedback", "mastering", "lufs", "loudness",
-        "audio quality", "mix review", "sonic", "frequency analysis",
+        "audio quality", "mix review", "sonic", "frequency analysis", "isrc",
     ],
     "distribution": [
         "dsp delivery", "metadata", "ddex", "spotify upload", "apple music",
@@ -85,7 +85,7 @@ ROUTING_TABLE = {
         "sample i used", "clear a sample",
     ],
     "publishing": [
-        "composition rights", "pro", "mechanical license", "songwriter splits", "isrc", "iswc",
+        "composition rights", "pro", "mechanical license", "songwriter splits", "iswc",
         "publishing royalties", "ascap", "bmi", "sesac", "song registration",
     ],
     "social": [

--- a/optimization/autoagent/tasks/routing-isrc/tests/test.py
+++ b/optimization/autoagent/tasks/routing-isrc/tests/test.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 def test_routing():
     """
-    Verifies that the agent correctly routes ISRC requests to the Publishing specialist.
+    Verifies that the agent correctly routes ISRC requests to the Music specialist.
     """
     print("Running ISRC Routing Test...")
     


### PR DESCRIPTION
- Moved `"isrc"` from `"publishing"` to `"music"` in `eval.py`'s `ROUTING_TABLE`.
- Updated `routing-isrc.json` to expect `"music"` instead of `"publishing"`.
- Updated `test.py` documentation to reflect the new routing behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Modified request routing logic so ISRC-related queries are directed to the Music agent.

* **Tests**
  * Updated test documentation to reflect the new routing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->