### PR TITLE
test(security): add SecurityDashboard render smoke test

### DIFF
--- a/packages/renderer/src/modules/security/SecurityDashboard.test.tsx
+++ b/packages/renderer/src/modules/security/SecurityDashboard.test.tsx
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import SecurityDashboard from './SecurityDashboard';
+
+describe('SecurityDashboard', () => {
+    it('renders all 4 panes', () => {
+        render(<SecurityDashboard />);
+        expect(screen.getByText('Security Center')).toBeDefined();
+        expect(screen.getByText('Access Control')).toBeDefined();
+        expect(screen.getByText('API Credentials')).toBeDefined();
+        expect(screen.getByText('Audit Trail')).toBeDefined();
+        expect(screen.getByText('Agent Encryption')).toBeDefined();
+    });
+
+    it('shows pending placeholders for not-yet-implemented panes', () => {
+        render(<SecurityDashboard />);
+        expect(screen.getByText(/Access Matrix Pending/)).toBeDefined();
+        expect(screen.getByText(/Credential Vault Pending/)).toBeDefined();
+        expect(screen.getByText(/Activity Log Pending/)).toBeDefined();
+        expect(screen.getByText(/E2E Diagnostics Pending/)).toBeDefined();
+    });
+});


### PR DESCRIPTION
Companion to fb4041b2. Asserts the 4-pane scaffold renders all expected section headings (Access Control, API Credentials, Audit Trail, Agent Encryption) and the "Pending" placeholder labels for not-yet-implemented panes — so future migration of any pane from placeholder to live data will fail the test loudly until the new content is asserted instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test suite for the Security Dashboard component, validating existing dashboard sections and placeholder states for upcoming features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->