### PR TITLE
test(agent): add generateStructuredData mock to AgentIntegration suite

### DIFF
--- a/packages/renderer/src/services/agent/AgentIntegration.test.ts
+++ b/packages/renderer/src/services/agent/AgentIntegration.test.ts
@@ -109,7 +109,11 @@ vi.mock('@/services/ai/GenAI', () => ({
             }
         }),
         generateContentStream: vi.fn(),
-        generateSpeech: vi.fn()
+        generateSpeech: vi.fn(),
+        // Stubbed because triggerAutorater fires post-completion through the
+        // MultiTurnAutorater. Returning null short-circuits the autorater's
+        // happy path so it doesn't try to write to Firestore from these tests.
+        generateStructuredData: vi.fn().mockResolvedValue(null)
     }
 }));
 


### PR DESCRIPTION
Root cause: AgentService.triggerAutorater (added in fb4041b2) fires post-completion in the success path. It calls
MultiTurnAutorater.evaluateTrace -> GenAI.generateStructuredData. The integration test only mocked generateContentStream/generateContent, so the autorater path crashed with "is not a function" — caught and swallowed by the autorater's try/catch, but logged as stderr noise on every test run.

The latent fragility: under full-suite execution (with file-level test ordering and shared module state) the unhandled rejection sometimes raced the test's 5-second timeout, producing the previously-reported 2 flakes in "should handle tool execution cycles" and "should prevent concurrent agent executions."

Fix: mock generateStructuredData to resolve null. The autorater short- circuits cleanly on null, no Firestore writes happen, no stderr noise, and the timeout pressure disappears (587ms now vs 5000ms timeout).

Verified: full Vitest suite green (587 files / 3576 passing / 0 failures).