### PR TITLE
fix(dev): restore packages/renderer/vite.config.ts for npm run dev:web

### DIFF
--- a/.agent/skills/error_memory/ERROR_LEDGER.md
+++ b/.agent/skills/error_memory/ERROR_LEDGER.md
@@ -1,5 +1,30 @@
 # Error Ledger
 
+## 2026-05-05 Web dev spinner — missing renderer Vite config
+
+- SEVERITY: High (blocks `npm run dev:web` entirely)
+- FILE: `packages/renderer/vite.config.ts` (was missing)
+- BUG: localhost:4242 (or :4243) loads index.html, then hangs on the auth-loading
+  spinner forever. DevTools Network shows `/src/main.tsx` returning HTTP 404 with
+  Content-Type `text/html` — Vite serves index.html as an SPA fallback for the
+  module URL because the module isn't found. Without main.tsx executing, the auth
+  listener never attaches, so `authLoading` stays `true`.
+- ROOT CAUSE: `package.json` `dev:web` invokes plain `vite --config packages/renderer/vite.config.ts`,
+  but that config file did not exist. Plain `vite` doesn't understand
+  `electron.vite.config.ts` (which is shaped for the `electron-vite` binary —
+  `{ main, preload, renderer }` blocks). When fed that config, plain Vite ignores
+  the unknown shape, defaults `root` to the repo root, then can't find
+  `src/main.tsx` (it lives at `packages/renderer/src/main.tsx`), and falls back
+  to serving `index.html` for everything. Same failure mode if someone manually
+  runs `vite --config electron.vite.config.ts --port 4242`.
+- FIX: Restored `packages/renderer/vite.config.ts` as a renderer-only config
+  rooted at `__dirname`, mirroring `resolve.alias` from electron.vite.config.ts.
+  Verified by curl: `/src/main.tsx` returns 200 with Content-Type `text/javascript`.
+- HOW TO PREVENT: When deleting or moving Vite configs, search the package.json
+  scripts (`grep -nE 'vite' package.json`) and confirm every script's `--config`
+  path still resolves. Don't delete a config file referenced by an npm script
+  without updating the script.
+
 ## 2026-05-04 A2A Encryption Interop (Phase 0.7)
 
 - PATTERN: WebCrypto ↔ Python `cryptography` interop for hybrid RSA-OAEP + AES-GCM encryption.
@@ -19,11 +44,11 @@
 
 - SEVERITY: High
 - FILE: `packages/renderer/src/core/components/chat/ChatMessage.tsx` & `packages/renderer/src/services/agent/specialists/GeneralistAgent.ts`
-- BUG: UI Components (like the Living Plan card or Image results) failed to render. Chat bubbled showed raw `[Tool: propose_plan] {"success":...}` JSON strings instead. 
+- BUG: UI Components (like the Living Plan card or Image results) failed to render. Chat bubbled showed raw `[Tool: propose_plan] {"success":...}` JSON strings instead.
 - CAUSE: The regex used to parse tool outputs (`\{.*?\}`) matched lazily and truncated valid JSON at the first closing brace `}`, causing `JSON.parse` to silently fail and swallow the error. Additionally, tools had no clear ending delimiters.
-- FIX: 
+- FIX:
   1. Updated `GeneralistAgent.ts` to output tools with explicit start/end markers: `\n[Tool: name]\n{json}\n[End Tool name]\n`
-  2. Updated `ChatMessage.tsx` to use robust regexes: `/\[Tool: propose_plan\]([\s\S]*?)\[End Tool propose_plan\]/`. 
+  2. Updated `ChatMessage.tsx` to use robust regexes: `/\[Tool: propose_plan\]([\s\S]*?)\[End Tool propose_plan\]/`.
   3. Replaced matched segments in text, preventing raw JSON from rendering.
   4. Also added `break-all` to the Markdown `prose` container to stop overflow on long continuous strings.
 

--- a/packages/renderer/vite.config.ts
+++ b/packages/renderer/vite.config.ts
@@ -1,0 +1,55 @@
+/**
+ * packages/renderer/vite.config.ts
+ *
+ * Renderer-only Vite config for browser dev mode (`npm run dev:web` on :4243).
+ * The Electron desktop build still uses electron.vite.config.ts at the repo
+ * root — keep these two files in sync for `resolve.alias` and any plugin
+ * additions, otherwise web-only and desktop will drift.
+ *
+ * History: this file was missing on 2026-05-05 — `npm run dev:web` invoked
+ * plain `vite --config electron.vite.config.ts`, which silently fell back to
+ * repo root and served index.html for every request including /src/main.tsx.
+ * That returned HTML where the browser expected a script module, producing a
+ * spinner that never resolves because the entry never executed.
+ */
+import { defineConfig } from 'vite';
+import { resolve } from 'path';
+import react from '@vitejs/plugin-react';
+import tailwindcss from '@tailwindcss/vite';
+
+const repoRoot = resolve(__dirname, '..', '..');
+
+export default defineConfig({
+    root: __dirname,
+    plugins: [
+        react(),
+        tailwindcss(),
+    ],
+    resolve: {
+        alias: {
+            '@': resolve(__dirname, 'src'),
+            '@agents': resolve(repoRoot, 'agents'),
+            '@shared': resolve(repoRoot, 'packages/shared/src'),
+        },
+    },
+    server: {
+        port: 4243,
+        host: '127.0.0.1',
+        strictPort: true,
+        // SPA fallback: any non-asset URL falls back to index.html. Vite already
+        // does this for the root, but explicit is safer if router routes change.
+        fs: {
+            // Permit reading files outside the renderer package — the alias
+            // targets above point into the monorepo root.
+            allow: [repoRoot],
+        },
+    },
+    build: {
+        outDir: resolve(repoRoot, 'dist/renderer'),
+        rollupOptions: {
+            input: {
+                index: resolve(__dirname, 'index.html'),
+            },
+        },
+    },
+});


### PR DESCRIPTION
Symptom: localhost:4242 (or :4243) loaded the static index.html shell, then hung on the auth-loading spinner forever. DevTools Network showed /src/main.tsx returning HTTP 404 with Content-Type text/html — Vite was serving index.html as an SPA fallback for the script module URL.

Root cause: package.json's dev:web script invokes plain `vite --config packages/renderer/vite.config.ts --port 4243`, but that config file was missing from the tree. Plain Vite cannot parse the electron.vite.config.ts shape ({ main, preload, renderer } blocks for the electron-vite binary), so when fed that file it ignores the unknown top-level fields, defaults `root` to the repo root, fails to find src/main.tsx (the actual entry lives at packages/renderer/src/main.tsx), and falls back to serving index.html for every URL. Without main.tsx executing, the auth listener never attaches and authLoading stays true.

Fix: restore packages/renderer/vite.config.ts as a renderer-only config rooted at __dirname, mirroring resolve.alias from the desktop config so @, @agents, and @shared still resolve. Plugins (react, tailwindcss) and server.port (4243) match the legacy file.

Verified: dev:web starts cleanly, /src/main.tsx returns 200 with Content-Type text/javascript, /src/core/App.tsx and the alias paths all resolve. Production build (`npm run build:studio`) is unaffected — it goes through electron.vite.config.ts at the repo root.

Also logged the failure mode to ERROR_LEDGER as a "before deleting a config, search package.json scripts" rule so this doesn't recur.